### PR TITLE
Fixup rule 13

### DIFF
--- a/addons/rules.py
+++ b/addons/rules.py
@@ -130,7 +130,7 @@ class Rules:
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
     async def r13(self):
         """Displays rule 13."""
-        await self.simple_embed("Ask a staff member before posting invite links to things like servers on Discord, Skype groups, etc.", title="Rule 13")
+        await self.simple_embed("Ask a staff member before advertising in our server or posting invite links to things like servers on Discord, Skype groups, etc.", title="Rule 13")
 
     @commands.command(hidden=True)
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)


### PR DESCRIPTION
This fixes r13 to correctly match the rule described in the rules channel.

This should hopefully reduce some of the backtalk people get when this command is invoked as it doesnt include the generic "advertising" part.