### PR TITLE
Add new piracy tool to filter

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -89,6 +89,7 @@ class Events:
         'vi1lian3ds',
         'vil1ian3ds',
         'cdnfx',
+        'exshop',
     )
 
     # terms that should cause a notice but not auto-delete

--- a/addons/events.py
+++ b/addons/events.py
@@ -89,7 +89,9 @@ class Events:
         'vi1lian3ds',
         'vil1ian3ds',
         'cdnfx',
+        'exhop',
         'exshop',
+        'exnhop',
     )
 
     # terms that should cause a notice but not auto-delete


### PR DESCRIPTION
Since it's not indexed by the big G yet or easily findable, [here](https://gbatemp.net/threads/release-exhop-nintendo-switch-title-downloader.508273/). Seems to be an equivalent of that one tool, so preparation for PRs for the cheap workarounds should probably be expected.

EDIT: did some more investigation, it appears to be a fork for the dump installer that can install to a selected title ID. Feel free to determine wether it still counts as piracy or not and wether you want to merge this PR.