### PR TITLE
Add two misspellings of a piracy tool

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -57,7 +57,9 @@ class Events:
         'makifbi',
         'utikdownloadhelper',
         'wiiuusbhelper',
-        'w11uusbh3lper'
+        'wiiusbhelper',
+        'w11uusbh3lper',
+        'w11usbh3lper',
         'funkii',
         'funkey',
         'funk11',


### PR DESCRIPTION
Also fixed the comma separation of one.