### PR TITLE
Various changes to mention spam check

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -297,22 +297,22 @@ class Events:
 
         # check for mention spam
         if len(message.mentions) >= 6 and not self.bot.helpers_role in message.author.roles:
-            log_msg = "⛔ **Auto-ban**: {} banned for mass user mentions | {}#{}\n🗓 __Creation__: {}\n🏷 __User ID__: {}".format(message.author.mention, message.author.name, message.author.discriminator, message.author.created_at, message.author.id)
+            log_msg = "🚫 **Auto-probate**: {} probated for mass user mentions | {}#{}\n🗓 __Creation__: {}\n🏷 __User ID__: {}".format(message.author.mention, message.author.name, message.author.discriminator, message.author.created_at, message.author.id)
             embed = discord.Embed(title="Deleted message", color=discord.Color.gold())
             embed.add_field(name="#" + message.channel.name,
                             value="\u200b" + message.content)
             await self.bot.send_message(self.bot.modlogs_channel, log_msg, embed=embed)
-            await self.bot.send_message(self.bot.mods_channel, log_msg + "\nSee {} for the deleted message.".format(self.bot.modlogs_channel.mention))
+            await self.bot.send_message(self.bot.mods_channel, log_msg + "\nSee {} for the deleted message. @here".format(self.bot.modlogs_channel.mention))
             try:
                 await self.bot.delete_message(message)
             except discord.errors.NotFound:
                 pass
             try:
-                await self.bot.send_message(message.author, "You were automatically banned from {} for mass user mentions.\n\nThis ban does not expire.".format(self.bot.server.name))
+                await self.bot.send_message(message.author, "You were automatically placed under probation in {} for mass user mentions.".format(self.bot.server.name))
             except discord.errors.Forbidden:
                 pass
-            self.bot.actions.append("ub:" + message.author.id)
-            await self.bot.ban(message.author, 0)
+            await self.add_restriction(message.author, "Probation")
+            await self.bot.add_roles(message.author, self.bot.probation_role)
 
 
     async def keyword_search(self, message):

--- a/addons/events.py
+++ b/addons/events.py
@@ -296,7 +296,7 @@ class Events:
             await self.bot.send_message(self.bot.messagelogs_channel, "**Bad site**: {} mentioned a blocked guide mirror in {} (message deleted)".format(message.author.mention, message.channel.mention), embed=embed)
 
         # check for mention spam
-        if len(message.mentions) >= 6:
+        if len(message.mentions) >= 6 and not self.bot.helpers_role in message.author.roles:
             log_msg = "⛔ **Auto-ban**: {} banned for mass user mentions | {}#{}\n🗓 __Creation__: {}\n🏷 __User ID__: {}".format(message.author.mention, message.author.name, message.author.discriminator, message.author.created_at, message.author.id)
             embed = discord.Embed(title="Deleted message", color=discord.Color.gold())
             embed.add_field(name="#" + message.channel.name,


### PR DESCRIPTION
* Exempt helpers explicitly: staff members are already exempted from the entire `scan_message` method. Future changes to code may want to consider splitting off specific checks to specific methods.
* Change enforcement action from ban to probate (also pings currently online staff members)