### PR TITLE
Various improvements to BMP conversion

### DIFF
--- a/addons/imgconvert.py
+++ b/addons/imgconvert.py
@@ -12,15 +12,15 @@ class ImageConvert:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
 
-    def img_convert(self, in_img):
-        img_obj = Image.open(BytesIO(in_img))
-        img_out = BytesIO()
-        img_obj.save(img_out, 'png')
-        img_out.seek(0)
-        return img_out
-
     async def on_message(self, message):
         # BMP conversion
+        def img_convert(self, in_img):
+            img_obj = Image.open(BytesIO(in_img))
+            img_out = BytesIO()
+            img_obj.save(img_out, 'png')
+            img_out.seek(0)
+            return img_out
+
         for f in message.attachments:
             if f["filename"].lower().endswith('.bmp') and f["size"] <= 600000:  # 600kb
                 async with aiohttp.ClientSession() as session:

--- a/addons/imgconvert.py
+++ b/addons/imgconvert.py
@@ -1,5 +1,7 @@
 from io import BytesIO
 import aiohttp
+import concurrent.futures
+import functools
 from PIL import Image
 
 class ImageConvert:
@@ -10,17 +12,22 @@ class ImageConvert:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
 
+    def img_convert(self, in_img):
+        img_obj = Image.open(BytesIO(in_img))
+        img_out = BytesIO()
+        img_obj.save(img_out, 'png')
+        img_out.seek(0)
+        return img_out
+
     async def on_message(self, message):
         # BMP conversion
         for f in message.attachments:
             if f["filename"].lower().endswith('.bmp') and f["size"] <= 600000:  # 600kb
                 async with aiohttp.ClientSession() as session:
-                    async with session.get(f["url"]) as img_request:
+                    async with session.get(f["url"], timeout=45) as img_request:
                         img_content = await img_request.read()
-                        img_obj = Image.open(BytesIO(img_content))
-                        img_out = BytesIO()
-                        img_obj.save(img_out, 'png')
-                        img_out.seek(0)
+                        with concurrent.futures.ProcessPoolExecutor() as pool:
+                            img_out = await self.bot.loop.run_in_executor(pool, functools.partial(img_convert, img_content))
                         out_message = "{} from {}".format(self.bot.escape_name(f["filename"]), message.author.mention)
                         new_filename = f["filename"][:-3] + "png"
                         await self.bot.send_file(message.channel, img_out, filename=new_filename, content=out_message)

--- a/addons/imgconvert.py
+++ b/addons/imgconvert.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-import requests
+import aiohttp
 from PIL import Image
 
 class ImageConvert:
@@ -14,14 +14,16 @@ class ImageConvert:
         # BMP conversion
         for f in message.attachments:
             if f["filename"].lower().endswith('.bmp') and f["size"] <= 600000:  # 600kb
-                img_request = requests.get(f["url"])
-                img_obj = Image.open(BytesIO(img_request.content))
-                img_out = BytesIO()
-                img_obj.save(img_out, 'png')
-                img_out.seek(0)
-                out_message = "{} from {}".format(self.bot.escape_name(f["filename"]), message.author.mention)
-                new_filename = f["filename"][:-3] + "png"
-                await self.bot.send_file(message.channel, img_out, filename=new_filename, content=out_message)
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f["url"]) as img_request:
+                        img_content = await img_request.read()
+                        img_obj = Image.open(BytesIO(img_content))
+                        img_out = BytesIO()
+                        img_obj.save(img_out, 'png')
+                        img_out.seek(0)
+                        out_message = "{} from {}".format(self.bot.escape_name(f["filename"]), message.author.mention)
+                        new_filename = f["filename"][:-3] + "png"
+                        await self.bot.send_file(message.channel, img_out, filename=new_filename, content=out_message)
 
 def setup(bot):
     bot.add_cog(ImageConvert(bot))


### PR DESCRIPTION
This PR makes the BMP->PNG conversion asynchronous. There are a few advantages to this:
- Mitigates a potential denial-of-service if something happens to go wrong with the Discord CDN
- Offloads BMP processing to a subprocess, avoiding blocking of the main event loop and improving responsiveness
  - This also opens the possibility of raising the maximum BMP filesize.