### PR TITLE
use MemberConverter instead for userinfo

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -51,14 +51,13 @@ class Mod:
         await self.bot.close()
 
     @commands.command(pass_context=True, hidden=True)
-    async def userinfo(self, ctx, user):
+    async def userinfo(self, ctx, u: discord.Member = None):
         """Gets user info. Staff and Helpers only."""
         issuer = ctx.message.author
         if (self.bot.helpers_role not in issuer.roles) and (self.bot.staff_role not in issuer.roles):
             msg = "{0} This command is limited to Staff and Helpers.".format(issuer.mention)
             await self.bot.say(msg)
             return
-        u = ctx.message.mentions[0]
         role = u.top_role.name
         if role == "@everyone":
             role = "@ everyone"


### PR DESCRIPTION
This eliminates the need to mention a user for userinfo, and allows matching by
- User ID alone
- Username/nickname (optionally with discriminator)

Related: #312.