### PR TITLE
Rewrite .stock message

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -39,7 +39,7 @@ class Assistance:
             await self.bot.say(msg)
             return
         await self.bot.delete_message(ctx.message)
-        # await self.bot.say("Request sent.")
+        # await self.bot("Request sent.")
         msg = "❗️ **Assistance requested**: {0} by {1} | {2}#{3} @here".format(ctx.message.channel.mention, author.mention, author.name, ctx.message.author.discriminator)
         if msg_request != "":
             # msg += "\n✏️ __Additional text__: " + msg_request
@@ -252,12 +252,16 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
             embed = discord.Embed(title="Running stock (unmodified) 11.4+ firmware?", color=discord.Color.dark_orange())
             embed.description = cleandoc("""
                 You have many possible options for installing CFW:
-                - You can install CFW for free on the latest firmware using the [Frogminer](https://3ds.hacks.guide/installing-boot9strap-\(frogminer\)) exploit
+                - You can install CFW for free on the latest firmware using the \
+[Frogminer](https://3ds.hacks.guide/installing-boot9strap-\(frogminer\)) exploit
                 
                 - Other methods:
-                - [NTRBoot](https://3ds.hacks.guide/ntrboot) which requires a compatible NDS flashcart. An additional DS(i) or hacked 3DS console **may** be required depending on the flashcart
-                - [Hardmod](https://3ds.hacks.guide/installing-boot9strap-\(hardmod\)) which requires soldering **(Not for beginners!)**
-                - See [the guide](https://3ds.hacks.guide/) for more methods and details about CFW installation on current and older frmwares.
+                - [NTRBoot](https://3ds.hacks.guide/ntrboot) which requires a compatible NDS flashcart. \
+An additional DS(i) or hacked 3DS console **may** be required depending on the flashcart
+                - [Hardmod](https://3ds.hacks.guide/installing-boot9strap-\(hardmod\)) which requires \
+soldering **(Not for beginners!)**
+                - See [the guide](https://3ds.hacks.guide/) for more methods and details about CFW \
+installation on current and older frmwares.
                 
                 Note: **Downgrading is impossible on 11.4+!**"
                 """)

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -210,7 +210,7 @@ class Assistance:
     async def stock(self):
         """Advisory for consoles on stock 11.4+ firmware"""
         embed = discord.Embed(title="Running stock (unmodified) 11.4+ firmware?", color=discord.Color.dark_orange())
-        embed.description = "You can install CFW for free using the [Frogminer](https://3ds.hacks.guide/installing-boot9strap-\(frogminer\)) exploit.\nFor other methods, see the [3ds Hacks Guide](https://3ds.hacks.guide)\n\nNote: **Downgrading is impossible on 11.4+!**"
+        embed.description = "You have many possible options for installing CFW:\n- You can install CFW for free on the latest firmware using the [Frogminer](https://3ds.hacks.guide/installing-boot9strap-\(frogminer\)) exploit\nOther methods:\n- [NTRBoot](https://3ds.hacks.guide/ntrboot) which requires a compatible NDS flashcart. An additional DS(i) or hacked 3DS console **may** be required depending on the flashcart\n- [Hardmod](https://3ds.hacks.guide/installing-boot9strap-\(hardmod\)) which requires soldering **(Not for beginners!)**\n- See [the guide](https://3ds.hacks.guide/) for more methods and details about CFW installation\n\nNote: **Downgrading is impossible on 11.4+!**"
         await self.bot.say("", embed=embed)
 
     @commands.command(aliases=["fuse-3ds", "fuse"])

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -205,7 +205,7 @@ class Assistance:
         embed.add_field(name="Check your 3DSs IP (Homebrew)", value="1. Open Homebrew Launcher\n2. Press Y")
         await self.bot.say("", embed=embed)
 
-    @commands.command(aliases=["stock114","stock115","stock116","stock117","stock118"])
+    @commands.command()
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
     async def stock(self):
         """Advisory for consoles on stock 11.4+ firmware"""

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -210,7 +210,7 @@ class Assistance:
     async def stock(self):
         """Advisory for consoles on stock 11.4+ firmware"""
         embed = discord.Embed(title="Running stock (unmodified) 11.4+ firmware?", color=discord.Color.dark_orange())
-        embed.description = "You have 4 possible options for installing CFW:\n- [NTRBoot](https://3ds.hacks.guide/ntrboot) which requires a compatible NDS flashcart and maybe an additional DS(i) or hacked 3DS console depending on the flashcart\n- [Frogminer](https://jisagi.github.io/FrogminerGuide) which requires a homebrew entrypoint like [steelminer](http://steelminer.jisagi.net/) (free method) or freakyhax\n- [Seedminer](https://3ds.hacks.guide/installing-boot9strap-\(seedminer\)) which requires a compatible DSiWare game\n- [Hardmod](https://3ds.hacks.guide/installing-boot9strap-\(hardmod\)) which requires soldering **Not for beginners!**\n **Downgrading is impossible on 11.4+!**"
+        embed.description = "You can install CFW for free using the [Frogminer](https://3ds.hacks.guide/installing-boot9strap-\(frogminer\)) exploit.\nFor other methods, see the [3ds Hacks Guide](https://3ds.hacks.guide)\n\nNote: **Downgrading is impossible on 11.4+!**"
         await self.bot.say("", embed=embed)
 
     @commands.command(aliases=["fuse-3ds", "fuse"])


### PR DESCRIPTION
- Rewrote the message in the stock command to incorporate The Guide:tm: for the frogminer method.
- Cleared up some messy grammar
- Removed rarely - if ever - used aliases (like .stock114, .stock115, etc. This can be reverted if you think these aliases were a vital feature).