### PR TITLE
nickname command added

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -463,7 +463,7 @@ class Mod:
             await self.bot.say("💢 I don't have permission to do this.")
 
     @commands.has_permissions(ban_members=True)
-    @commands.command(pass_context=True, name="nickname", aliases=["nick"])
+    @commands.command(pass_context=True, name="nickname")
     async def nickname(self, ctx, member: discord.Member, *, nickname):
         """Gives a user a nickname."""
         try:

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -464,7 +464,7 @@ class Mod:
 
     @commands.has_permissions(ban_members=True)
     @commands.command(pass_context=True, name="nickname", aliases=["nick"])
-    async def nickname(self, ctx, member, *, nickname):
+    async def nickname(self, ctx, member: discord.Member, *, nickname):
         """Gives a user a nickname."""
         try:
             if len(nickname) < 2 or len(nickname) > 32:

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -462,5 +462,17 @@ class Mod:
         except discord.errors.Forbidden:
             await self.bot.say("💢 I don't have permission to do this.")
 
+    @commands.has_permissions(ban_members=True)
+    @commands.command(pass_context=True, name="nickname", aliases=["nick"])
+    async def nickname(self, ctx, member, *, nickname):
+        """Gives a user a nickname."""
+        try:
+            if len(nickname) < 2 or len(nickname) > 32:
+                msg = "{} The nickname must be between 2 and 32 characters long.".format(ctx.message.author.mention)
+                return await self.bot.say(msg)
+            await self.bot.change_nickname(member, nickname)
+        except discord.errors.Forbidden:
+            await self.bot.say("💢 I don't have permission to do this.")
+
 def setup(bot):
     bot.add_cog(Mod(bot))


### PR DESCRIPTION
Mobile can't rename people, which is annoying. The command either accepts `nickname` or `nick` and limits the new nickname to 2-32 characters, according to discords [api limitations](https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames).

Syntax: `.nickname|nick <user-mention> newNickname`
