### PR TITLE
implement SafeMember converter

### DIFF
--- a/addons/converters.py
+++ b/addons/converters.py
@@ -1,0 +1,27 @@
+from discord.ext import commands
+import re
+
+
+class SafeMember(commands.Converter):
+    # A re-implementation of https://github.com/Rapptz/discord.py/blob/1863a1c6636f53592519320a173ec9573c090c0b/discord/ext/commands/converter.py
+    def convert(self):
+        message = self.ctx.message
+        match = re.match(r'([0-9]{15,21})$', self.argument) or re.match(r'<@!?([0-9]+)>$', self.argument)
+        server = message.server
+        result = None
+        if match is None:
+            # not a mention...
+            if server and "#" in self.argument:
+                result = server.get_member_named(self.argument)
+                if result is None:
+                    raise commands.errors.BadArgument('Member "{}" not found. Search terms are case sensitive.'.format(self.argument))
+            else:
+                raise commands.errors.BadArgument('Matches by only nick/username are not allowed.')
+        else:
+            user_id = match.group(1)
+            if server:
+                result = server.get_member(user_id)
+            if result is None:
+                raise commands.errors.BadArgument('Member "{}" not found.'.format(user_id))
+
+        return result

--- a/addons/mod_warn.py
+++ b/addons/mod_warn.py
@@ -3,6 +3,7 @@ import json
 import time
 from discord.ext import commands
 from addons.checks import is_staff, check_staff
+from addons import converters
 
 class ModWarn:
     """
@@ -14,7 +15,7 @@ class ModWarn:
 
     @is_staff('Helper')
     @commands.command(pass_context=True)
-    async def warn(self, ctx, member: discord.Member, *, reason=""):
+    async def warn(self, ctx, member: converters.SafeMember, *, reason=""):
         """Warn a user. Staff and Helpers only."""
         issuer = ctx.message.author
         if check_staff(member.id, "HalfOP"):
@@ -156,7 +157,7 @@ class ModWarn:
 
     @is_staff("HalfOP")
     @commands.command(pass_context=True)
-    async def delwarn(self, ctx, member: discord.Member, idx: int):
+    async def delwarn(self, ctx, member: converters.SafeMember, idx: int):
         """Remove a specific warn from a user. Staff only."""
         with open("data/warnsv2.json", "r") as f:
             warns = json.load(f)
@@ -214,7 +215,7 @@ class ModWarn:
 
     @is_staff("HalfOP")
     @commands.command(pass_context=True)
-    async def clearwarns(self, ctx, member: discord.Member):
+    async def clearwarns(self, ctx, member: converters.SafeMember):
         """Clear all warns for a user. Staff only."""
         with open("data/warnsv2.json", "r") as f:
             warns = json.load(f)
@@ -258,7 +259,7 @@ class ModWarn:
     @clearwarns.error
     async def warn_error_handler(self, error, ctx):
         if isinstance(error, commands.errors.BadArgument):
-            await self.bot.say("User not found. Search terms are case sensitive.")
+            await self.bot.say(error)
 
 
 def setup(bot):


### PR DESCRIPTION
This PR implements a safer version of the Member converter, which blocks potential imprecise matches by pure nick/username (underlying library returns first match). Matches by ID, mention, or username#discriminator still work as per normal.