### PR TITLE
Some other tools to the filter

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -57,10 +57,7 @@ class Events:
         'makiversion',
         'makifbi',
         'utikdownloadhelper',
-        'wiiuusbhelper',
-        'wiiusbhelper',
-        'w11uusbh3lper',
-        'w11usbh3lper',
+        'usbh3lper',
         'funkii',
         'funkey',
         'funk11',
@@ -100,7 +97,9 @@ class Events:
         'cdnsp',
         'wareznx',
         'wareznext',
-        'softcobra',
+        'uwizard',
+        'jnustool',
+        'nusgrabber',
     )
 
     # use the full ID, including capitalization and dashes


### PR DESCRIPTION
one of this was mentioned the other day, just adding it and another two in case (also removed wiiuusbhelper and similar, usbhelper alone should catch those)

* New non-critical features are not being added to the master branch. Please check the [new-and-improved](https://github.com/ihaveamac/Kurisu/tree/new-and-improved) branch for the Kurisu rewrite.
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
