### PR TITLE
add 3ds bad ticket error

### DIFF
--- a/addons/err.py
+++ b/addons/err.py
@@ -229,6 +229,7 @@ class Err:
         '007-2404': 'An error occurred while attempting to connect to the Nintendo eShop.\nMake sure you are running the latest firmware, since this error will appear if you are trying to access the eShop on older versions.',
         '007-2720': 'SSL error?',
         '007-2916': 'HTTP error, server is probably down. Try again later?',
+        '007-2920': 'This error is caused by installing a game or game update from an unofficial source, as it contains a bad ticket.\nThe only solution is to delete the unofficial game or update as well as its ticket\nin FBI, and install the game or update legitimately.',
         '007-2913': 'HTTP error, server is probably down. Try again later?',
         '007-2923': 'The Nintendo Servers are currently down for maintenance. Please try again later.',
         '007-3102': 'Cannot find title on Nintendo eShop. Probably pulled.',


### PR DESCRIPTION
as far as we can tell, 007-2920 is an illegitimate ticket error, updated to reflect this
