### PR TITLE
Add .exfat command to explain why exFAT shouldn't be used on the Switch

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -686,5 +686,19 @@ your device will refuse to write to it.
         embed.description = "A Community-maintained homebrew database"
         await self.bot.say("", embed=embed)
 
+    @commands.command()
+    @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
+    async def exfat(self):
+        """exFAT on Switch: why not to use it"""
+        await self.simple_embed("""
+                                The recommended filesystem format for the Switch is FAT32. 
+                                
+                                While the Switch supports exFAT through an additional update from Nintendo, here are reasons not to use it:
+                                
+                                * This filesystem is prone to corruption.
+                                * Nintendo does not use files larger than 4GB even while exFAT is used.
+                                """
+                                , title="exFAT on Switch: Why you shouldn't use it")
+
 def setup(bot):
     bot.add_cog(Assistance(bot))


### PR DESCRIPTION
This comes up almost every day in #switch-assistance, so it'd be handy to have a quick command to explain why it's not advisable to use it.

In addition to what the guide says, the Switch does not use files > 4GB even if exFAT is in use (easily verified by checking your Nintendo folder while using exFAT, no single file in there will be > 4GB).