### PR TITLE
Fixing Autorcm info command

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -720,14 +720,16 @@ You would need to inject Hekate and select `Power off` from the menu to fully tu
     async def nxban(self):
         """Switch ban risk snippet"""
         await self.simple_embed("""
-                                The Switch is a much more secure system than the 3DS, and Nintendo has upped their game when it comes to bans. 
-                                One of the main reasons for this is that there are significantly more monitoring systems, \
-                                some of which cannot be turned off.
-                                Remember that you can only reduce your chances of getting banned; nothing is guaranteed and you could be banned \
-                                at any time if you decide to hack your device. It will always be a cat and mouse game, until or unless there are big changes \
-                                in the scene. \
-                                Refer to #faq-switch for a list of things to avoid doing to reduce your risks.
-                                You cannot ask about unbanning your console here.
+                                The Switch is a much more secure system than the 3DS, and Nintendo has upped their game when it comes to bans. \
+One of the main reasons for this is that there are significantly more monitoring systems, \
+some of which cannot be turned off.
+
+Remember that you can only reduce your chances of getting banned; nothing is guaranteed and you could be banned \
+ at any time if you decide to hack your device. It will always be a cat and mouse game, until or unless there are big changes \
+in the scene. 
+ 
+Refer to #faq-switch for a list of things to avoid doing to reduce your risks.
+You cannot ask about unbanning your console here.
                                 """, title="Switch Bans")
 
 def setup(bot):

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -722,13 +722,12 @@ If you see the battery icon on the top left of the screen, then the console is c
                                 The Switch is a much more secure system than the 3DS, and Nintendo has upped their game when it comes to bans. \
 One of the main reasons for this is that there are significantly more monitoring systems, \
 some of which cannot be turned off.
-
-Remember that you can only reduce your chances of getting banned; nothing is guaranteed and you could be banned \
- at any time if you decide to hack your device. It will always be a cat and mouse game, until or unless there are big changes \
+                                Remember that you can only reduce your chances of getting banned; nothing is guaranteed and you could be banned \
+at any time if you decide to hack your device. It will always be a cat and mouse game, until or unless there are big changes \
 in the scene. 
- 
-Refer to #faq-switch for a list of things to avoid doing to reduce your risks.
-You cannot ask about unbanning your console here.
+
+                                Refer to #faq-switch for a list of things to avoid doing to reduce your risks.
+                                You cannot ask about unbanning your console here.
                                 """, title="Switch Bans")
 
 def setup(bot):

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -693,10 +693,9 @@ your device will refuse to write to it.
 You would need to inject Hekate and select `Power off` from the menu to fully turn the console off.
                                 
                                 • You will depend on your SD Card to take advantage of CFW. If your microSD is unavailable, you can only boot into stock firmware. \
-                                `**Warning: if performed a fuseless update from <4.1.0, booting stock __will__ update your game card slot, rendering it unusable when you run <4.1.0!
+`**Warning: if performed a fuseless update from <4.1.0, booting stock __will__ update your game card slot, rendering it unusable when you run <4.1.0!`
                                 • The console charges slowly in RCM. To solve this, boot Hekate, then inject Atmosphère.\
-                                If you see the battery icon on the top left of the screen, then the console is charging at its normal speed.
-
+If you see the battery icon on the top left of the screen, then the console is charging at its normal speed.
                                 To use AutoRCM, boot `Hekate` > `Tools` > `AutoRCM`. To uninstall, go to the same location.
                                 For more information, visit [this thread](https://gbatemp.net/threads/autorcm-with-the-nintendo-switch-101.515402/).
                                  """, title="Information about AutoRCM")


### PR DESCRIPTION
Previous edits were probably auto-formatted to include non-compatible line matching or whatecer. Buncha spaces deleted

* New non-critical features are not being added to the master branch. Please check the [new-and-improved](https://github.com/ihaveamac/Kurisu/tree/new-and-improved) branch for the Kurisu rewrite.
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
