### PR TITLE
Switch Serial Number Checking cog

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -24,7 +24,6 @@
 # reasonable ways as different from the original version; or
 
 # Also licensed under the ISC license.
-import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 import re

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -28,7 +28,7 @@ class SwitchSerialNumberCheck(Cog):
         assembly_line = int(serial[3])
         checking_value = int(serial[3:10])
         print(f"{checking_value} : {len(str(checking_value))}")
-        safe_serial = serial[:9] + 'X'
+        safe_serial = serial[:9] + 'XXXX'
 
         if region == 'J':
             if assembly_line == 1:

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,29 +1,3 @@
-# kirigiri - A discord bot.
-# Copyright (C) 2018 - Valentijn "noirscape" V.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation at version 3 of the License.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# In addition, the additional clauses 7b and 7c are in effect for this program.
-#
-# b) Requiring preservation of specified reasonable legal notices or
-# author attributions in that material or in the Appropriate Legal
-# Notices displayed by works containing it; or
-#
-# c) Prohibiting misrepresentation of the origin of that material, or
-# requiring that modified versions of such material be marked in
-# reasonable ways as different from the original version; or
-
-# Also licensed under the ISC license.
 from discord.ext import commands
 from discord.ext.commands import Cog
 import re

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,0 +1,90 @@
+import discord
+from discord.ext import commands
+from discord.ext.commands import Cog
+import re
+
+
+def setup(bot):
+    bot.add_cog(SwitchSerialNumberCheck(bot))
+
+
+class SwitchSerialNumberCheck(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(aliases=["ssnc"])
+    async def check_nx_serial(self, ctx, serial):
+        """Check the given Switch serial to see if it is patched or not. For safety reasons, the invoking message is
+        removed."""
+        serial = serial.split()[0].upper()
+        if not re.match("XA[JWK][1479][0-9]{6}", serial):
+            return await ctx.send("This is not a valid serial number!\n"
+                                  "If you believe this to be in error, contact staff.")
+
+        patched = False
+        maybe = False
+        region = serial[2]
+
+        assembly_line = int(serial[3])
+        checking_value = int(serial[3:10])
+        print(f"{checking_value} : {len(str(checking_value))}")
+        safe_serial = serial[:9] + 'X'
+
+        if region == 'J':
+            if assembly_line == 1:
+                if 1002100 <= checking_value <= 1002999:
+                    maybe = True
+                elif checking_value >= 1003000:
+                    pass
+
+            elif assembly_line == 4:
+                if 4004700 <= checking_value <= 4005999:
+                    maybe = True
+                elif checking_value >= 4006000:
+                    pass
+
+            elif assembly_line == 7:
+                if 7004100 <= checking_value <= 7004999:
+                    maybe = True
+                elif checking_value >= 7005000:
+                    pass
+
+            elif assembly_line == 9:
+                maybe = True
+
+        elif region == 'W':
+            if assembly_line == 1:
+                if 1007900 <= checking_value <= 1008199:
+                    maybe = True
+                elif checking_value >= 1008200:
+                    pass
+
+            elif assembly_line == 4:
+                if 4001200 <= checking_value <= 4002999:
+                    maybe = True
+                elif checking_value >= 4003000:
+                    pass
+
+            elif assembly_line == 7:
+                if 7001790 <= checking_value <= 7002999:
+                    maybe = True
+                elif checking_value >= 7003000:
+                    pass
+
+        elif region == 'K':
+            maybe = True
+
+        try:
+            await ctx.message.delete()
+        except:
+            pass
+
+        if maybe:
+            return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
+                                  "pushing the payload manually. You can find instructions to do so here: "
+                                  "https://nh-server.github.io/switch-guide/extras/rcm_test/".format(ctx.author.mention,
+                                                                                                     safe_serial))
+        elif patched:
+            return await ctx.send("{}: Serial {} is patched.".format(ctx.author.mention, safe_serial))
+        else:
+            return await ctx.send("{}: Serial {} is not patched.".format(ctx.author.mention, safe_serial))

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,3 +1,19 @@
+#ISC License
+#
+# Copyright (c) 2019, Valentijn "noirscape" V.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 from discord.ext import commands
 from discord.ext.commands import Cog
 import re

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,4 +1,3 @@
-import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 import re

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,3 +1,30 @@
+# kirigiri - A discord bot.
+# Copyright (C) 2018 - Valentijn "noirscape" V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation at version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# In addition, the additional clauses 7b and 7c are in effect for this program.
+#
+# b) Requiring preservation of specified reasonable legal notices or
+# author attributions in that material or in the Appropriate Legal
+# Notices displayed by works containing it; or
+#
+# c) Prohibiting misrepresentation of the origin of that material, or
+# requiring that modified versions of such material be marked in
+# reasonable ways as different from the original version; or
+
+# Also licensed under the ISC license.
+import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 import re
@@ -26,49 +53,61 @@ class SwitchSerialNumberCheck(Cog):
 
         assembly_line = int(serial[3])
         checking_value = int(serial[3:10])
-        print(f"{checking_value} : {len(str(checking_value))}")
         safe_serial = serial[:9] + 'XXXX'
 
         if region == 'J':
             if assembly_line == 1:
-                if 1002100 <= checking_value <= 1002999:
+                if checking_value < 1002000:
+                    pass
+                elif 1002000 <= checking_value < 1003000:
                     maybe = True
                 elif checking_value >= 1003000:
-                    pass
+                    patched = True
 
             elif assembly_line == 4:
-                if 4004700 <= checking_value <= 4005999:
+                if checking_value < 4004600:
+                    pass
+                elif 4004600 <= checking_value < 4006000:
                     maybe = True
                 elif checking_value >= 4006000:
-                    pass
+                    patched = True
 
             elif assembly_line == 7:
-                if 7004100 <= checking_value <= 7004999:
+                if checking_value < 7004000:
+                    pass
+                elif 7004000 <= checking_value < 7005000:
                     maybe = True
                 elif checking_value >= 7005000:
-                    pass
-
-            elif assembly_line == 9:
-                maybe = True
+                    patched = True
 
         elif region == 'W':
             if assembly_line == 1:
-                if 1007900 <= checking_value <= 1008199:
-                    maybe = True
-                elif checking_value >= 1008200:
+                if checking_value < 1007400:
                     pass
+                elif 1007400 <= checking_value < 1012000:  # GBATemp thread is oddly disjointed here, proper value could
+                    # be 1007500, not sure.
+                    maybe = True
+                elif checking_value >= 1012000:
+                    patched = True
 
             elif assembly_line == 4:
-                if 4001200 <= checking_value <= 4002999:
-                    maybe = True
-                elif checking_value >= 4003000:
+                if checking_value < 4001100:
                     pass
+                elif 4001100 <= checking_value < 4001200:
+                    maybe = True
+                elif checking_value >= 4001200:
+                    patched = True
 
             elif assembly_line == 7:
-                if 7001790 <= checking_value <= 7002999:
+                if checking_value < 7001780:
+                    pass
+                elif 7001780 <= checking_value < 7003000:
                     maybe = True
                 elif checking_value >= 7003000:
-                    pass
+                    patched = True
+
+            elif assembly_line == 9:
+                maybe = True
 
         elif region == 'K':
             maybe = True

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -1,4 +1,4 @@
-#ISC License
+# ISC License
 #
 # Copyright (c) 2019, Valentijn "noirscape" V.
 #

--- a/kurisu.py
+++ b/kurisu.py
@@ -47,6 +47,7 @@ cogs = [
     'cogs.mod',
     'cogs.nxerr',
     'cogs.rules',
+    'cogs.ssnc',
 ]
 
 


### PR DESCRIPTION
Adds a cog to check Switch Serials.

I promised I'd write this for NH ages ago, then did but couldn't be arsed to backport it to async. Given we're now _finally_ on rewrite, that means I don't have to backport it.

Basically, you can submit any serial and it'll verify if it's correct. It removes the invoking message in case someone submits their full serial number into it and blots out the potentially identifying bits when returning it.