### PR TITLE
Update obsolete (and now broken) link

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -109,7 +109,7 @@ class SwitchSerialNumberCheck(Cog):
         if maybe:
             return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
                                   "pushing the payload manually. You can find instructions to do so here: "
-                                  "https://nh-server.github.io/switch-guide/extras/rcm_test/".format(ctx.author.mention,
+                                  "https://nh-server.github.io/switch-guide/user_guide/sending_payload/".format(ctx.author.mention,
                                                                                                      safe_serial))
         elif patched:
             return await ctx.send("{}: Serial {} is patched.".format(ctx.author.mention, safe_serial))


### PR DESCRIPTION
We changed the Switch guide slightly, so the old link is now removed and thus broken.