### PR TITLE
Suspend filtering SX OS, it's getting in the way of legit questions and discussion

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -138,6 +138,7 @@ class Events(DatabaseCog):
         'notabug',
         #'sx',
         #'tx',
+        'sxos',
     )
 
     drama_alert = ()

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -123,7 +123,7 @@ class Events(DatabaseCog):
         'stargate',
         'freestore',
         'sxinstaller',
-        'sxos',
+        #'sxos',
     )
 
     # use the full ID, including capitalization and dashes


### PR DESCRIPTION
I was originally all for deleting it on sight but it's getting in the way of people asking legit questions, like how to move to Atmosphere and things like that, and it then prompts people to try and bypass the filter.