### PR TITLE
Update PR and contributing templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,2 +1,3 @@
-* New non-critical features are not being added to the master branch. Please check the [new-and-improved](https://github.com/ihaveamac/Kurisu/tree/new-and-improved) branch for the Kurisu rewrite.
+<!--
 * If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,3 @@
-* New non-critical features are not being added to the master branch. Please check the [new-and-improved](https://github.com/ihaveamac/Kurisu/tree/new-and-improved) branch for the Kurisu rewrite.
+<!--
 * If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
+-->


### PR DESCRIPTION
This updates the PR and issue templates.

With `port` replacing `new-and-improved`, the line about non critical features is irrelevant (and has been irrelevant for the past couple months as need has often surpassed the importance of that notice).

Also commented out the filter list notice, that way it won't appear on opened Pull Requests anymore.