### PR TITLE
Add validity checks for .luma versions

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -496,7 +496,7 @@ the system can't check for an update.
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
     async def luma(self, ctx, lumaversion=""):
         """Download links for Luma versions"""
-        if lumaversion != "":
+        if len(lumaversion) >= 3 and lumaversion[0].isdigit() and lumaversion[1] == "." and lumaversion[2].isdigit():
             await self.simple_embed(ctx, f"Luma v{lumaversion}\nhttps://github.com/AuroraWright/Luma3DS/releases/tag/v{lumaversion}", color=discord.Color.blue())
         else:
             await self.simple_embed(ctx, """

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -498,6 +498,8 @@ the system can't check for an update.
         """Download links for Luma versions"""
         if len(lumaversion) >= 3 and lumaversion[0].isdigit() and lumaversion[1] == "." and lumaversion[2].isdigit():
             await self.simple_embed(ctx, f"Luma v{lumaversion}\nhttps://github.com/AuroraWright/Luma3DS/releases/tag/v{lumaversion}", color=discord.Color.blue())
+        elif lumaversion == "latest"
+            await self.simple_embed(ctx, f"Latest Luma Version:\nhttps://github.com/AuroraWright/Luma3DS/releases/latest", color=discord.Color.blue())
         else:
             await self.simple_embed(ctx, """
                                     Download links for the most common Luma3DS releases:

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -498,8 +498,8 @@ the system can't check for an update.
         """Download links for Luma versions"""
         if len(lumaversion) >= 3 and lumaversion[0].isdigit() and lumaversion[1] == "." and lumaversion[2].isdigit():
             await self.simple_embed(ctx, f"Luma v{lumaversion}\nhttps://github.com/AuroraWright/Luma3DS/releases/tag/v{lumaversion}", color=discord.Color.blue())
-        elif lumaversion == "latest"
-            await self.simple_embed(ctx, f"Latest Luma Version:\nhttps://github.com/AuroraWright/Luma3DS/releases/latest", color=discord.Color.blue())
+        elif lumaversion == "latest":
+            await self.simple_embed(ctx, "Latest Luma Version:\nhttps://github.com/AuroraWright/Luma3DS/releases/latest", color=discord.Color.blue())
         else:
             await self.simple_embed(ctx, """
                                     Download links for the most common Luma3DS releases:


### PR DESCRIPTION
Original problem:
![IMG_20190505_214829](https://user-images.githubusercontent.com/14542417/57199484-a7e76400-6f7f-11e9-86c4-067b5d4d0600.jpg)

Fix:
Check that the string is at least 3 characters long and is in the format `DIGIT.DIGIT`.
Otherwise, it states the default message with the commonly used versions.
This still allows for longer versions like `7.0.5`, `9.0-joyconhax` or (unfortunately) other random garbage after the first three characters.

Simultaneously, made the command `.luma latest` give the correct, latest version, as it doesn't follow the same logic as standard numbered versions.
