### PR TITLE
Updated tinysearch

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1,5 +1,6 @@
 import aiohttp
 import discord
+import urllib.parse
 
 from cogs.checks import check_staff_id
 from discord.ext import commands
@@ -861,10 +862,10 @@ your device will refuse to write to it.
         """Search for your favorite homebrew app in tinydb"""
         if app == ():
             return await ctx.send("Enter a app name to search!")
-        app = "_".join(app).replace(" ", "_").replace("..", "_")
+        app = " ".join(app)
         async with aiohttp.ClientSession() as session:
             try:
-                async with session.get(f"https://tinydb.eiphax.tech/api/search/{app}", timeout=2) as resp:
+                async with session.get(f"https://tinydb.eiphax.tech/api/search/{urllib.parse.quote(app)}", timeout=2) as resp:
                     response = await resp.json()
             except aiohttp.ClientConnectionError:
                 return await ctx.send("I can't connect to tinydb 💢")

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -857,10 +857,11 @@ your device will refuse to write to it.
 
     @commands.command(aliases=["tinydbsearch"])
     @commands.cooldown(rate=1, per=15.0, type=commands.BucketType.channel)
-    async def tinysearch(self, ctx, app: str = ""):
+    async def tinysearch(self, ctx, *app):
         """Search for your favorite homebrew app in tinydb"""
-        if not app:
+        if app == ():
             return await ctx.send("Enter a app name to search!")
+        app = "_".join(app).replace(" ", "_").replace("..", "_").replace("/", "_")
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(f"https://tinydb.eiphax.tech/api/search/{app}", timeout=2) as resp:

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -858,16 +858,14 @@ your device will refuse to write to it.
 
     @commands.command(aliases=["tinydbsearch"])
     @commands.cooldown(rate=1, per=15.0, type=commands.BucketType.channel)
-    async def tinysearch(self, ctx, *app):
+    async def tinysearch(self, ctx, *, app=""):
         """Search for your favorite homebrew app in tinydb"""
-        if app == ():
+        if not app or app.startswith(".."):
             return await ctx.send("Enter a search term to search for applications.")
-        app = " ".join(app)
-        appurlencode= urllib.parse.quote(app.replace("..", "/"))
+        encodedapp = urllib.parse.quote(app)
         async with aiohttp.ClientSession() as session:
-        	
             try:
-                async with session.get(f"https://tinydb.eiphax.tech/api/search/{appurlencode}", timeout=2) as resp:
+                async with session.get(f"https://tinydb.eiphax.tech/api/search/{encodedapp}", timeout=2) as resp:
                     response = await resp.json()
             except aiohttp.ClientConnectionError:
                 return await ctx.send("I can't connect to tinydb 💢")

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -860,7 +860,7 @@ your device will refuse to write to it.
     @commands.cooldown(rate=1, per=15.0, type=commands.BucketType.channel)
     async def tinysearch(self, ctx, *, app=""):
         """Search for your favorite homebrew app in tinydb"""
-        if not app or app.startswith(".."):
+        if not app or app.startswith("..") or "/.." in app:
             return await ctx.send("Enter a search term to search for applications.")
         encodedapp = urllib.parse.quote(app)
         async with aiohttp.ClientSession() as session:

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -863,9 +863,11 @@ your device will refuse to write to it.
         if app == ():
             return await ctx.send("Enter a search term to search for applications.")
         app = " ".join(app)
+        appurlencode= urllib.parse.quote(app.replace("..", "/"))
         async with aiohttp.ClientSession() as session:
+        	
             try:
-                async with session.get(f"https://tinydb.eiphax.tech/api/search/{urllib.parse.quote(app)}", timeout=2) as resp:
+                async with session.get(f"https://tinydb.eiphax.tech/api/search/{appurlencode}", timeout=2) as resp:
                     response = await resp.json()
             except aiohttp.ClientConnectionError:
                 return await ctx.send("I can't connect to tinydb 💢")

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -861,7 +861,7 @@ your device will refuse to write to it.
     async def tinysearch(self, ctx, *app):
         """Search for your favorite homebrew app in tinydb"""
         if app == ():
-            return await ctx.send("Enter a app name to search!")
+            return await ctx.send("Enter a search term to search for applications.")
         app = " ".join(app)
         async with aiohttp.ClientSession() as session:
             try:

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -861,7 +861,7 @@ your device will refuse to write to it.
         """Search for your favorite homebrew app in tinydb"""
         if app == ():
             return await ctx.send("Enter a app name to search!")
-        app = "_".join(app).replace(" ", "_").replace("..", "_").replace("/", "_")
+        app = "_".join(app).replace(" ", "_").replace("..", "_")
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(f"https://tinydb.eiphax.tech/api/search/{app}", timeout=2) as resp:


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->
I fixed a small bug that create an unexpected exeption when we do .tinysearch .. (or .tinysearch something/something. Well, it work, i was sure it wasnt) 
(There could be a better way to do that.) Tanks deadphoenix8091

And, user can now search apps with a space in their name, like homebrew launcher. (Right now, user can type homebrew_launcher to get it.)