### PR TITLE
Update events.py

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -107,7 +107,6 @@ class Events(DatabaseCog):
         'jnustool',
         'nusgrabber',
         'fr33$h0p',
-        'fshop',  # common outright bypass, but not sure if it will interact with legitimate words
         'free.shop',
         'fréeshop',
         'freéshop',
@@ -141,6 +140,7 @@ class Events(DatabaseCog):
         'freshop',
         'feeshop',
         'notabug',
+        'fshop',
         #'sx',
         #'tx',
         'sxos',


### PR DESCRIPTION
Moving "fshop" from piracy_tools to piracy_tools_alert so people can say 'a lot of shops" without their message being deleted