### PR TITLE
new filter addition: 'portalrom'

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -185,6 +185,7 @@ class Events(DatabaseCog):
         'doperoms',
         'freeroms',
         'portableroms',
+        'portalrom',
         'portalroms',
         'romulation',
         'emulator.games',


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->