### PR TITLE
Update events.py

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -147,9 +147,7 @@ class Events(DatabaseCog):
         'sxos',
         'operationidroid',
         'hbg',
-        'blawar',
         'mercury',
-        'vertigo',
     )
 
     drama_alert = ()


### PR DESCRIPTION
Removed blawar and vertigo from piracy_tools_alert as those are not piracy tools and have given nothing but false positives since they were added.