### PR TITLE
Update events.py

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -148,6 +148,7 @@ class Events(DatabaseCog):
         'operationidroid',
         'hbg',
         'mercury',
+        'lithium',
     )
 
     drama_alert = ()


### PR DESCRIPTION
Lithium is a "stripped down" version of Tinfoil for end-users, and as there is no use-case for lithium metal as a jig (unlike tinfoil) adding this alert shouldn't cause false-positive issues like tinfoil would, at least not any more than the existing entry of mercury or similar.