### PR TITLE
removed that ) from the slowmode desc

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -104,7 +104,7 @@ class Mod(DatabaseCog):
     async def slowmode(self, ctx, time, channel: discord.TextChannel=None):
         """Apply a given slowmode time to a channel.
         
-        The time format is identical to that used for timed kicks/bans/takehelps.)
+        The time format is identical to that used for timed kicks/bans/takehelps.
 
         It is not possible to set a slowmode longer than 6 hours.
         


### PR DESCRIPTION
it's kinda pointless but it irks me

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->