### PR TITLE
Updated exfat command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -954,8 +954,9 @@ your device will refuse to write to it.
                                 
                                 While the Switch supports exFAT through an additional update from Nintendo, here are reasons not to use it:
                                 
+                                * CFW may fail to boot due to a missing exFAT update in Horizon
                                 * This filesystem is prone to corruption.
-                                * Nintendo does not use files larger than 4GB even while exFAT is used.
+                                * Nintendo doesn't use files larger than 4GB, even with large games and exFAT. 
                                 """, title="exFAT on Switch: Why you shouldn't use it")
         
     @commands.command()


### PR DESCRIPTION
Singlehandedly the extensive commit in Kurisu history.
Reworded the last point to address large games directly and warned about booting Horizon without exFAT updates.
