### PR TITLE
Added a precision for the .approve command description

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -526,7 +526,7 @@ class Mod(DatabaseCog):
     @commands.guild_only()
     @commands.command(hidden=True)
     async def approve(self, ctx, invite: discord.Invite, times: int=1):
-        """Approves a server invite for a number of times"""
+        """Approves a server invite for a number of times. Staff and Helpers only."""
         code = invite.code
         self.bot.temp_guilds[code] = times
         await ctx.send(f"Approved an invite to {invite.guild}({code}) for posting {times} times")


### PR DESCRIPTION
It now says who can use it

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->