### PR TITLE
Update nxupdate command.

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -765,8 +765,7 @@ firmware version in System Settings.
 ***Hold*** Volume Down and Volume Up, then Power. When you see Maintenance Mode, you \
 may reboot, and check System Settings.
                                 
-                                *To block automatic update downloads, enter 163.172.141.219 as your primary DNS and \
-45.248.48.62 as your secondary DNS for your home network.*
+                                *To block automatic update downloads, type .90dns in this chat for further information.*
                                  """, title="How to delete pending Switch Updates")
 
     @commands.command()


### PR DESCRIPTION
This removes the issue of having to update both .90dns and .nxupdate whenever the 90DNS IPs change. Furthermore, the 90dns command has exact setup instructions rather than just vaguely telling the user to set them blindly.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->