### PR TITLE
added an alias to .troubleshoot

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -468,7 +468,7 @@ just missing a file called boot.firm in the root of your SD card.
         embed.add_field(name="Checking your SD for errors or corruption", value="https://3ds.eiphax.tech/sderrors.html \n Please read the instructions carefully.", inline=False)
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(aliases=["troubleshooting"])
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
     async def troubleshoot(self, ctx, *, console=""):
         """Troubleshooting guides for common issues"""


### PR DESCRIPTION
.troubleshoot: exists
win: i must add .troubleshooting

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->