### PR TITLE
Add new piracy tool

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -129,6 +129,7 @@ class Events(DatabaseCog):
         'rajnx2',
         'poyoshop',
         'pbanjgasm',
+        'goldbrick'
 
         #'sxos',
     )


### PR DESCRIPTION
Technically the full name is GoldBricks, but goldbrick catches it just as well.