### PR TITLE
fix slowmode logging

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -133,7 +133,7 @@ class Mod(DatabaseCog):
             await channel.edit(slowmode_delay=seconds)
         except discord.errors.Forbidden:
             return await ctx.send("💢 I don't have permission to do this.")
-        msg = f"🕙 **Slowmode**: {ctx.author.mention} set a slowmode delay of {time} ({seconds}) in {ctx.channel.mention}"
+        msg = f"🕙 **Slowmode**: {ctx.author.mention} set a slowmode delay of {time} ({seconds}) in {channel.mention}"
         await self.bot.channels["mod-logs"].send(msg)
 
     @is_staff("HalfOP")


### PR DESCRIPTION
Channel being passed in context is the channel being messaged in, not the channel being mentioned in the message

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->