### PR TITLE
fixed a stupid mistake i made

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -977,7 +977,7 @@ your device will refuse to write to it.
         embed.description = "Basic tutorial for TWiLightMenu++"
         await ctx.send(embed=embed)
 
-    @tutorial.command(aliases=["forwarders", "forwarder" "twlforwarders"])
+    @tutorial.command(aliases=["forwarders", "forwarder", "twlforwarders"])
     async def ndsforwarders(self, ctx):
         """Links to nds forwarders"""
         embed = discord.Embed(title="NDS Forwarder Guide", color=discord.Color.purple())


### PR DESCRIPTION
yes i forgot a comma

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->