### PR TITLE
fixed a cmd error i made that got PRed on accident

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -977,7 +977,7 @@ your device will refuse to write to it.
         embed.description = "Basic tutorial for TWiLightMenu++"
         await ctx.send(embed=embed)
 
-    @tutorial.command(aliases=["forwarders", "forwarder" "twlforwarders"])
+    @tutorial.command(aliases=["forwarders", "forwarder", "twlforwarders"])
     async def ndsforwarders(self, ctx):
         """Links to nds forwarders"""
         embed = discord.Embed(title="NDS Forwarder Guide", color=discord.Color.purple())


### PR DESCRIPTION
maybe this time it wont mess with some other cog for no good reason

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->