### PR TITLE
3ds stuff: add a new 'ntrcart' command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1183,5 +1183,15 @@ in the scene.
 
                                 Note that if hekate can't find a config, it'll create one. So likely you now have a hekate_ipl.ini in your bootloader folder, replace it with the one from the guide
                                 """, title="Getting the \"No main boot entries found\" error in hekate?")
+
+    @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
+    @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
+    async def ntrcart(self, ctx):
+        imagelink = "https://i.imgur.com/nvnObqz.png"
+        title = "Which flashcarts work with NTRBoot?"		
+        embed = discord.Embed(title=title, color=discord.Color.default())
+        embed.set_image(url=imagelink)
+        await ctx.send(embed=embed)
+
 def setup(bot):
     bot.add_cog(Assistance(bot))


### PR DESCRIPTION
At the request of win9x and krieg: it displays the list of ntrboot-compatible NDS flashcarts from the 3DS FAQ.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->