### PR TITLE
Show issuing channels for .warn and .softwarn

### DIFF
--- a/cogs/mod_warn.py
+++ b/cogs/mod_warn.py
@@ -131,7 +131,6 @@ class ModWarn(DatabaseCog):
 
         await ctx.send(f"{member.mention} softwarned. User has {warn_count} warning(s)")
         msg = f"⚠️ **Warned**: {issuer.mention} softwarned {member.mention} in {channel.mention} ({self.bot.escape_text(channel)}) (warn #{warn_count}) | {self.bot.escape_text(member)}"
-        msg = f"⚠️ **Warned**: {issuer.mention} softwarned {member.mention} (warn #{warn_count}) | {self.bot.escape_text(member)}"
         reason = self.bot.escape_text(reason)
         signature = utils.command_signature(self.warn)
         if reason != "":

--- a/cogs/mod_warn.py
+++ b/cogs/mod_warn.py
@@ -20,6 +20,7 @@ class ModWarn(DatabaseCog):
     async def warn(self, ctx, member: SafeMember, *, reason=""):
         """Warn a user. Staff and Helpers only."""
         issuer = ctx.author
+        channel = ctx.channel
         if await check_bot_or_staff(ctx, member, "warn"):
             return
         await self.add_warn(member.id, ctx.author.id, reason)
@@ -53,7 +54,7 @@ class ModWarn(DatabaseCog):
             except discord.Forbidden:
                 await ctx.send("I can't ban this user!")
         await ctx.send(f"{member.mention} warned. User has {warn_count} warning(s)")
-        msg = f"⚠️ **Warned**: {issuer.mention} warned {member.mention} (warn #{warn_count}) | {member}"
+        msg = f"⚠️ **Warned**: {issuer.mention} warned {member.mention} in {channel.mention} ({channel}) (warn #{warn_count}) | {member}"
         if reason != "":
             # much \n
             msg += "\n✏️ __Reason__: " + reason
@@ -64,6 +65,7 @@ class ModWarn(DatabaseCog):
     async def softwarn(self, ctx, member: SafeMember, *, reason=""):
         """Warn a user without automated action. Staff only."""
         issuer = ctx.author
+        channel = ctx.channel
         if await check_bot_or_staff(ctx, member, "warn"):
             return
         warn_count = len(await self.get_warns(member.id))
@@ -84,7 +86,7 @@ class ModWarn(DatabaseCog):
             pass  # don't fail in case user has DMs disabled for this server, or blocked the bot
 
         await ctx.send(f"{member.mention} softwarned. User has {warn_count} warning(s)")
-        msg = f"⚠️ **Warned**: {issuer.mention} softwarned {member.mention} (warn #{warn_count}) | {member}"
+        msg = f"⚠️ **Warned**: {issuer.mention} softwarned {member.mention} in {channel.mention} ({channel}) (warn #{warn_count}) | {member}"
         if reason != "":
             # much \n
             msg += "\n✏️ __Reason__: " + reason


### PR DESCRIPTION
I wont be able to do it for .listwarns because this one is too complicated

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->