### PR TITLE
Adding Switch Error Code 2016-2101

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -51,7 +51,10 @@ class Assistance:
     @commands.cooldown(rate=1, per=30.0, type=commands.BucketType.channel)
     async def guide(self, ctx, *, consoles="None"):
         """Links to the recommended guides."""
-        consoleslist = [x for x in consoles.split() if x in self.systems]      
+        consoleslist = []
+        for x in consoles.split():
+            if x in self.systems and x not in consoleslist:
+                consoleslist.append(x)
         if not consoleslist:
             if ctx.message.channel.name.startswith(self.systems):
                 consoleslist.append("None")

--- a/addons/events.py
+++ b/addons/events.py
@@ -120,6 +120,9 @@ class Events:
         '\hbg\shop',
         'hbgsh0p',
         'stargate',
+        'freestore',
+        'sxinstaller',
+        'sxos',
     )
 
     # use the full ID, including capitalization and dashes
@@ -132,6 +135,8 @@ class Events:
         'freshop',
         'feeshop',
         'notabug',
+        'sx',
+        'tx',
     )
 
     drama_alert = ()

--- a/addons/events.py
+++ b/addons/events.py
@@ -135,8 +135,8 @@ class Events:
         'freshop',
         'feeshop',
         'notabug',
-        'sx',
-        'tx',
+        #'sx',
+        #'tx',
     )
 
     drama_alert = ()

--- a/addons/extras.py
+++ b/addons/extras.py
@@ -198,7 +198,16 @@ class Extras:
                     await self.bot.add_roles(author, self.bot.elsewhere_role)
                     await self.bot.send_message(author, "Access to #elsewhere granted.")
                 else:
-                    await self.bot.send_message(author, "Your access to elsewhere is restricted, contact staff to remove it.")
+                    await self.bot.send_message(author, "Your access to #elsewhere is restricted, contact staff to remove it.")
+            if channelname == "artswhere":
+                if self.bot.art_role in author.roles:
+                    await self.bot.remove_roles(author, self.bot.art_role)
+                    await self.bot.send_message(author, "Access to #art-discussion removed.")
+                elif self.bot.noart_role not in author.roles:
+                    await self.bot.add_roles(author, self.bot.art_role)
+                    await self.bot.send_message(author, "Access to #art-discussion granted.")
+                else:
+                    await self.bot.send_message(author, "Your access to #art-discussion is restricted, contact staff to remove it.")
             else:
                 await self.bot.send_message(author, "{} is not a valid toggleable channel.".format(channelname))
         except discord.errors.Forbidden:

--- a/addons/logs.py
+++ b/addons/logs.py
@@ -18,6 +18,7 @@ You can find a list of staff and helpers in {2}.
 
 Do you simply need a place to start hacking your 3DS system? Check out **<https://3ds.hacks.guide>**!
 Do you simply need a place to start hacking your Wii U system? Check out **<https://wiiu.hacks.guide/>**!
+Do you simply need a place to start hacking your Switch system? Check out **<https://nh-server.github.io/switch-guide/>**!
 
 By participating in this server, you acknowledge that user data (including messages, user IDs, user tags) will be collected and logged for moderation purposes. If you disagree with this collection, please leave the server immediately.
 

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -221,6 +221,41 @@ class Mod:
 
     @is_staff("HalfOP")
     @commands.command(pass_context=True)
+    async def art(self, ctx, member: converters.SafeMember):
+        """Restore art-discussion access for a user. Staff only."""
+        try:
+            await self.remove_restriction(member, "no-art")
+            await self.bot.remove_roles(member, self.bot.noart_role)
+            await self.bot.say("{} can access art-discussion again.".format(member.mention))
+            msg = "⭕️ **Restored art**: {} restored art access to {} | {}#{}".format(ctx.message.author.mention, member.mention, self.bot.escape_name(member.name), self.bot.escape_name(member.discriminator))
+            await self.bot.send_message(self.bot.modlogs_channel, msg)
+        except discord.errors.Forbidden:
+            await self.bot.say("💢 I don't have permission to do this.")
+
+    @is_staff("HalfOP")
+    @commands.command(pass_context=True)
+    async def noart(self, ctx, member: converters.SafeMember, *, reason=""):
+        """Removes art-discussion access from a user. Staff only."""
+        try:
+            await self.add_restriction(member, "no-art")
+            roles = member.roles
+
+            roles = [x for x in roles if x != self.bot.art_role]
+            if self.bot.noart_role not in roles:
+                roles.append(self.bot.noart_role)
+            await self.bot.replace_roles(member, *roles)
+            await self.bot.say("{} can no longer access art-discussion.".format(member.mention))
+            msg = "🚫 **Removed art**: {} removed art access from {} | {}#{}".format(ctx.message.author.mention, member.mention, self.bot.escape_name(member.name), self.bot.escape_name(member.discriminator))
+            if reason != "":
+                msg += "\n✏️ __Reason__: " + reason
+            else:
+                msg += "\nPlease add an explanation below. In the future, it is recommended to use `.noart <user> [reason]` as the reason is automatically sent to the user."
+            await self.bot.send_message(self.bot.modlogs_channel, msg)
+        except discord.errors.Forbidden:
+            await self.bot.say("💢 I don't have permission to do this.")
+
+    @is_staff("HalfOP")
+    @commands.command(pass_context=True)
     async def elsewhere(self, ctx, member: converters.SafeMember):
         """Restore elsewhere access for a user. Staff only."""
         try:

--- a/run.py
+++ b/run.py
@@ -67,7 +67,7 @@ for fp in _filepaths:
         with open(fp, "w") as inf:
             json.dump({}, inf)
 
-bot = commands.Bot(command_prefix=['!', '.'], description="Kurisu, the bot for the 3DS Hacking Discord!", pm_help=None)
+bot = commands.Bot(command_prefix=['!', '.'], description="Kurisu, the bot for the Nintendo Homebrew Discord server!", pm_help=None)
 
 bot.actions = []  # changes messages in mod-/server-logs
 with open("data/watch.json", "r") as f:

--- a/run.py
+++ b/run.py
@@ -190,6 +190,8 @@ async def on_ready():
         bot.noembed_role = discord.utils.get(server.roles, name="No-Embed")
         bot.elsewhere_role = discord.utils.get(server.roles, name="#elsewhere")
         bot.noelsewhere_role = discord.utils.get(server.roles, name="no-elsewhere")
+        bot.art_role = discord.utils.get(server.roles, name="#art-discussion")
+        bot.noart_role = discord.utils.get(server.roles, name="no-art")
         bot.smallhelp_role = discord.utils.get(server.roles, name="Small Help")
         bot.everyone_role = server.default_role
 


### PR DESCRIPTION
2016-2101 happens when a Tencent-Nintendo Switch cartridge is inserted into regular Switch.
Notice that [https://nintendoswitch.com.cn/support](https://nintendoswitch.com.cn/support) didn't mention the cartridge region lock issue. But since Nintendo Switch system says visit such website for support, it's in the error information as is.