### PR TITLE
Escape the member's name in the log message

### DIFF
--- a/cogs/logs.py
+++ b/cogs/logs.py
@@ -170,7 +170,7 @@ Thanks for boosting and have a good time!
                 msg = "\n🏷 __Nickname change__"
             msg += f": {self.bot.escape_text(member_before.nick)} → {self.bot.escape_text(member_after.nick)}"
         if do_log:
-            msg = f"ℹ️ **Member update**: {member_after.mention} | {member_after} {msg}"
+            msg = f"ℹ️ **Member update**: {member_after.mention} | {self.bot.escape_text(member_after)} {msg}"
             await dest.send(msg)
 
     @commands.Cog.listener()


### PR DESCRIPTION
PR fixes:
- Log messages "breaking" because of certain symbols in usernames in the on_member_update listener