### PR TITLE
small change to emptysd

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -688,8 +688,7 @@ the system can't check for an update.
         """What to do if you delete all your SD card contents"""
         await self.simple_embed(ctx, """
                                 If you have lost the contents of your SD card with CFW, you will need in SD root:
-                                -`boot.3dsx` from Homebrew launcher [here](https://github.com/fincs/new-hbmenu/releases/latest/)
-                                -`boot.firm` from [luma3ds latest release](https://github.com/AuroraWright/Luma3DS/releases/latest)
+                                -`boot.firm` and `boot.3dsx` from [luma3ds latest release](https://github.com/AuroraWright/Luma3DS/releases/latest)
                                 Then repeat the [finalizing setup](https://3ds.hacks.guide/finalizing-setup) page.
                                 """, color=discord.Color.red())
 


### PR DESCRIPTION
emptysd links both hbl and luma but the luma release archive also contains boot.3dsx
(this pr isn't exactly necessary but why not)