### PR TITLE
Update ssnc.py to support Tencent-Nintendo Switch

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -45,7 +45,8 @@ class SwitchSerialNumberCheck(Cog):
             # XKW10000000000, XKJ10000000000 = HAC-001-01, the "New Switch"
             # XJW01000000000, XWW01000000000 = HDH-001, the Switch Lite
             # As not much about the assembly line is known yet every digit will count for the filter
-            if re.match("X[KJW][JW][0-9]{7}", serial):
+            if re.match("X[KJW][JWC][0-9]{7}", serial):
+            # Region "C" is Tencent-Nintendo Switch. Mariko.
                 mariko = True
             else:
                 return await ctx.send("This is not a valid serial number!\n"


### PR DESCRIPTION
Only 1 character modification. Region "C" is Tencent-Nintendo Switch. Mariko.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->