### PR TITLE
Add sx alias for sxos in nxcfw

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -562,7 +562,16 @@ re-read the guide steps 2 or 3 times before coming here.
                         * It does not support loading custom system modules.
                         * Several versions of the CFW have caused users to be banned without their knowledge.""", 
                 'title': "SX OS"
+            },
+            'sx': {
+                'info': """
+                        * SX OS is illegal to purchase and own. It bundles various keys and copyrighted data that cannot be legally shared.
+                        * It has known compatibility issues with homebrew, due to its non-standard and proprietary nature.
+                        * It does not support loading custom system modules.
+                        * Several versions of the CFW have caused users to be banned without their knowledge.""", 
+                'title': "SX OS"
             }
+
         }
 
         if not (info := cfwinfo.get(cfw)):


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->