### PR TITLE
Add help text for invite command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1287,11 +1287,11 @@ in the scene.
 
     @commands.command()
     @commands.cooldown(rate=1, per=5.0, type=commands.BucketType.channel)
-    async def invite(self, ctx, code: str):
-        """Available codes are:
+    async def invite(self, ctx, name: str):
+        """Available servers are:
         twl, switchroot, acnl, flagbrew, themeplaza, smash, ndsbrew, citra, homebrew, skyrimnx, pkhexautolegality, reswitched, cemu, dragoninjector, vita, henkaku, universal, r3DS"""
         
-        code = code.lower()
+        name = name.lower()
         invites = {
             'twl':'yD3spjv',
             'switchroot': '9d66FYg',
@@ -1313,10 +1313,10 @@ in the scene.
             'r3DS': '3ds'
         }
         #Rewrite thanks to Dax#5790
-        if code in invites:
-            await ctx.send(f"https://discord.gg/{invites[code]}")
+        if name in invites:
+            await ctx.send(f"https://discord.gg/{invites[name]}")
         else:
-            await ctx.send(f"Invalid invite code. Valid codes: {', '.join(invites.keys())}")
+            await ctx.send(f"Invalid invite code. Valid server names are: {', '.join(invites.keys())}")
 
     @commands.guild_only()
     @commands.command()

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1288,6 +1288,9 @@ in the scene.
     @commands.command()
     @commands.cooldown(rate=1, per=5.0, type=commands.BucketType.channel)
     async def invite(self, ctx, code: str):
+        """Available codes are:
+        twl, switchroot, acnl, flagbrew, themeplaza, smash, ndsbrew, citra, homebrew, skyrimnx, pkhexautolegality, reswitched, cemu, dragoninjector, vita, henkaku, universal, r3DS"""
+        
         code = code.lower()
         invites = {
             'twl':'yD3spjv',


### PR DESCRIPTION
I can't find a better way of doing this. I thought putting the list outside the function and using """{}""".format(join(invites.keys())) would work but it doesn't get shown when .help is used.