### PR TITLE
Stop tutorials.themes from being used in DMs

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1094,6 +1094,7 @@ NAND backups, and SD card contents. Windows, macOS, and Linux are supported.
         embed.description = "A tutorial about how to transfer a save from the cart version of a game to a digital version of that game."
         await ctx.send(embed=embed)
 
+    @commands.guild_only()
     @tutorial.command(aliases=["theme"])
     async def themes(self, ctx, console=None):
         """Links to the relevant games database"""


### PR DESCRIPTION
Not sure if it's intended for the tutorial group to be
usable in DMs (i can only see little benefit), most work
fine tho.
.themes is multiconsole and so it tries to get the channel name
which will fail in a DmChannel.
