### PR TITLE
Change the 90dns instructions

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1229,15 +1229,11 @@ in the scene.
                                 The public 90DNS IP adresses are:
                                 - `207.246.121.77` (USA)
                                 - `163.172.141.219`(France)
-                                
-                                To set these go to System Settings -> Internet -> Connection Settings -> Your wifi Network -> DNS to Manual -> Set primary and secondary DNS to the previously listed IPs -> Save Settings.
 
-                                Set the primary DNS server to the IP that is closest to you and the other as your secondary DNS.
-                                
-                                You will have to manually set these for each WiFi connection you have set up.
-                                
-                                [Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/#testing-if-your-90dns-connection-is-working) to ensure that the connection is safe and not blocked by your ISP.
-                                """, title="90DNS IP adressses")
+                                To set these [follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/)
+
+                                You will have to manually set these for each WiFi connection you have set up.""",
+                                title="90DNS IP adressses")
 
     @commands.command(aliases=['missingco'])
     async def missingconfig(self, ctx):

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1230,7 +1230,7 @@ in the scene.
                                 - `207.246.121.77` (USA)
                                 - `163.172.141.219`(France)
 
-                                To set these [follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/)
+                                [Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up 90dns and ensure it isn't being blocked
 
                                 You will have to manually set these for each WiFi connection you have set up.""",
                                 title="90DNS IP adressses")


### PR DESCRIPTION
Direct to the 90dns page on the switch guide rather than restate the instructions.
Provides instructions whether the user has wifi networks set up or not and shortens the embed