### PR TITLE
Remove goodshop from filter, it causes more problems than it solves

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -96,7 +96,6 @@ class Events(DatabaseCog):
         'exhop',
         'exshop',
         'enxhop',
-        'goodshop',
         'exnhop',  # typo of the above, not sure how common
         'enxshop',  # also typo
         'cdnsp',


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->