### PR TITLE
Whitelist lovepotion dev server in invite command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1345,7 +1345,8 @@ in the scene.
             'switchlan': 'SbxDMER',
             'ctgp7': '0uTPwYv3SPQww54l',
             'retronx': 'vgvZN9W',
-            'r3ds': '3ds'
+            'r3ds': '3ds',
+            'lovepotion' : 'ggbKkhc',
         }
 
         if name in invites:


### PR DESCRIPTION
3DS/Switch port of Love2D by TurtleP; questions about it pop up every now and then, so it doesn't hurt to whitelist it.
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->