### PR TITLE
Add CBHC Rules Command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1414,6 +1414,20 @@ in the scene.
             """))
         await ctx.send(embed=embed)
 
+    @commands.command(aliases=['cbhc'])
+    async def cbhcrules(self, ctx):
+        """The rules for the CBHC CFW on Wii U to avoid a brick"""
+        embed = discord.Embed(title="Installing CBHC incorrectly can brick your Wii U!", color=discord.Color.red())
+        embed.add_field(name="Make sure to follow the following rules when installing CBHC:", value=cleandoc("""
+                - The DS game has to be legitimately installed from the eShop!
+                - Don’t format the system while CBHC is installed!
+                - Don’t delete the user account that bought the DS VC game!
+                - Don’t re-install the same game using WUP Installer or from the eShop!
+                - Don’t install Haxchi over CBHC!
+                - Don’t uninstall the DS Virtual Console game without [properly uninstalling CBHC first](https://wiiu.hacks.guide/#/uninstall-cbhc)!
+                - Don’t move the DS Virtual Console game to a USB drive!
+            """))
+        await ctx.send(embed=embed)
 
 def setup(bot):
     bot.add_cog(Assistance(bot))

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1423,7 +1423,7 @@ in the scene.
                 - Don’t format the system while CBHC is installed!
                 - Don’t delete the user account that bought the DS VC game!
                 - Don’t re-install the same game using WUP Installer or from the eShop!
-                - Don’t install Haxchi over CBHC!
+                - Don’t install Haxchi over CBHC! (You will not brick, but it will cause a boot-loop! Hold A when booting to access the Homebrew Launcher and uninstall CBHC.)
                 - Don’t uninstall the DS Virtual Console game without [properly uninstalling CBHC first](https://wiiu.hacks.guide/#/uninstall-cbhc)!
                 - Don’t move the DS Virtual Console game to a USB drive!
             """))


### PR DESCRIPTION
When one considers the CBHC custom firmware for their Wii U, they often ask about the brick risks involved in using it. This command will have Kurisu post an embed with a section from our guide (https://wiiu.hacks.guide/#/cfw-choice) to help explain how to avoid bricks. This should make it much easier for our helpers when they are asked about the risks of using CBHC.