### PR TITLE
Add usm command to link to the guide page

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1428,5 +1428,12 @@ in the scene.
             """))
         await ctx.send(embed=embed)
 
+    @commands.command(aliases=['usm'])
+    async def unsafe_mode(self, ctx):
+        embed = discord.Embed(title="Unsafe_mode Guide Page", color=discord.Color.dark_orange())
+        embed.url = "https://3ds.hacks.guide/installing-boot9strap-(usm)"
+        embed.description = "The 3DS Guide page on using Unsafe_mode."
+        await ctx.send(embed=embed)
+        
 def setup(bot):
     bot.add_cog(Assistance(bot))


### PR DESCRIPTION
The title says it all really. I suspect this command might be temporarily but it'll be useful given how many people we are currently redirecting away from steelhax and fredtool. 