### PR TITLE
Workaround broken hyperlinking on discord mobile

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1432,7 +1432,7 @@ in the scene.
     async def unsafe_mode(self, ctx):
         """unSAFE_MODE Guide"""
         await self.simple_embed(ctx, """
-                    3DS Hacks Guide's [unSAFE_MODE](https://3ds.hacks.guide/installing-boot9strap-(usm))
+                    3DS Hacks Guide's [unSAFE_MODE](https://3ds.hacks.guide/installing-boot9strap-(usm).html)
                     """, title="unSAFE_MODE")
 
         


### PR DESCRIPTION
Last change to this (I promise)
Discord mobile doesn't correctly link if a close bracket is at the end of a link (ends link early causing the link to be "https://3ds.hacks.guide/installing-boot9strap(usm ") adding .html seems to fix this.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->