### PR TITLE
Show warning when friend codes are from Tencent-Nintendo Switches

### DIFF
--- a/cogs/friendcode.py
+++ b/cogs/friendcode.py
@@ -33,7 +33,7 @@ class FriendCode(DatabaseCog):
         """Add your friend code."""
         fc = self.verify_fc(fc)
         if not fc:
-            await ctx.send("This friend code is invalid.")
+            await ctx.send("This friend code is invalid.\nPlease notice: friend codes from Tencent-Nintendo Switches are currently not supported.")
             return
         rows = await self.get_friendcode(ctx.author.id)
         for row in rows:
@@ -74,7 +74,7 @@ class FriendCode(DatabaseCog):
         if fc:
             await ctx.send(self.fc_to_string(fc))
         else:
-            await ctx.send("Invalid.")
+            await ctx.send("Invalid.\nPlease notice: friend codes from Tencent-Nintendo Switches are currently not supported.")
 
 
 def setup(bot):


### PR DESCRIPTION
Currently friend code related functions will consider friend codes from Tencent-Nintendo Switch invalid. To prevent confusing users, before understanding the formats difference in Tencent-Nintendo Switch generated codes so we can parse them, a warning will be given to users.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->