### PR TITLE
Approve bitbuilt for invite command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1347,7 +1347,8 @@ in the scene.
             'ctgp7': '0uTPwYv3SPQww54l',
             'retronx': 'vgvZN9W',
             'r3ds': '3ds',
-            'lovepotion' : 'ggbKkhc',
+            'lovepotion': 'ggbKkhc',
+            'bitbuilt': 'tHEesfb',
         }
 
         if name in invites:


### PR DESCRIPTION
It's the discord for this community https://bitbuilt.net/forums/ , it has around 1,000 members and seems to be where various console portablizing projects exist. Their rules align with ours, so I don't see a reason to turn it down.
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->