### PR TITLE
Change permissions for userinfo2

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -56,7 +56,7 @@ class Mod(DatabaseCog):
         
         if user is None:
             user = ctx.author
-        if (ctx.channel.name == "bot-cmds" and ctx.author == user) or await check_staff_id(ctx, 'Helper', ctx.author.id):
+        if (ctx.channel == self.bot.channels["bot-cmds"] and ctx.author == user) or await check_staff_id(ctx, 'Helper', ctx.author.id):
                                 
             embed = discord.Embed(color=utils.gen_color(user.id))
             embed.description = (

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -48,7 +48,6 @@ class Mod(DatabaseCog):
                 ban = None
             await ctx.safe_send(f"{basemsg}{f'**Banned**, reason: {ban.reason}' if ban is not None else ''}\n")
 
-    
     @commands.guild_only()
     @commands.command(aliases=['ui2'])
     async def userinfo2(self, ctx, user: FetchMember = None):
@@ -91,6 +90,7 @@ class Mod(DatabaseCog):
             await ctx.send(embed=embed)
         else:
             raise discord.ext.commands.errors.CheckFailure(f'The check functions for command {ctx.command} failed.')
+
     @is_staff("HalfOP")
     @commands.guild_only()
     @commands.command()

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -48,44 +48,49 @@ class Mod(DatabaseCog):
                 ban = None
             await ctx.safe_send(f"{basemsg}{f'**Banned**, reason: {ban.reason}' if ban is not None else ''}\n")
 
-    @is_staff("Helper")
+    
     @commands.guild_only()
     @commands.command(aliases=['ui2'])
-    async def userinfo2(self, ctx, user: FetchMember):
+    async def userinfo2(self, ctx, user: FetchMember = None):
         """Shows information from a user. Staff and Helpers only."""
-
-        embed = discord.Embed(color=utils.gen_color(user.id))
-        embed.description = (
-            f"**User:** {user.mention}\n"
-            f"**User's ID:** {user.id}\n"
-            f"**Created on:** {user.created_at}\n"
-            f"**Default Profile Picture:** {user.default_avatar}\n"
-        )
-
-        if isinstance(user, discord.Member):
-            member_type = "member"
-            embed.description += (
-                f"**Join date:** {user.joined_at}\n"
-                f"**Current Status:** {user.status}\n"
-                f"**User Activity:**: {user.activity}\n"
-                f"**Current Display Name:** {user.display_name}\n"
-                f"**Nitro Boost Info:** {user.premium_since}\n"
-                f"**Current Top Role:** {user.top_role}\n"
-                f"**Color:** {user.color}\n"
+        
+        if user is None:
+            user = ctx.author
+        if (ctx.channel.name == "bot-cmds" and ctx.author == user) or await check_staff_id(ctx, 'Helper', ctx.author.id):
+                                
+            embed = discord.Embed(color=utils.gen_color(user.id))
+            embed.description = (
+                f"**User:** {user.mention}\n"
+                f"**User's ID:** {user.id}\n"
+                f"**Created on:** {user.created_at}\n"
+                f"**Default Profile Picture:** {user.default_avatar}\n"
             )
+
+            if isinstance(user, discord.Member):
+                member_type = "member"
+                embed.description += (
+                    f"**Join date:** {user.joined_at}\n"
+                    f"**Current Status:** {user.status}\n"
+                    f"**User Activity:**: {user.activity}\n"
+                    f"**Current Display Name:** {user.display_name}\n"
+                    f"**Nitro Boost Info:** {user.premium_since}\n"
+                    f"**Current Top Role:** {user.top_role}\n"
+                    f"**Color:** {user.color}\n"
+                )
+            else:
+                member_type = "user"
+                try:
+                    ban = await ctx.guild.fetch_ban(user)
+                    embed.description += f"\n**Banned**, reason: {ban.reason}"
+                except discord.NotFound:
+                    pass
+
+            member_type = member_type if not user.bot else "bot"
+            embed.title = f"**Userinfo for {member_type} {user}**"
+            embed.set_thumbnail(url=user.avatar_url_as(static_format='png'))
+            await ctx.send(embed=embed)
         else:
-            member_type = "user"
-            try:
-                ban = await ctx.guild.fetch_ban(user)
-                embed.description += f"\n**Banned**, reason: {ban.reason}"
-            except discord.NotFound:
-                pass
-
-        member_type = member_type if not user.bot else "bot"
-        embed.title = f"**Userinfo for {member_type} {user}**"
-        embed.set_thumbnail(url=user.avatar_url_as(static_format='png'))
-        await ctx.send(embed=embed)
-
+            raise discord.ext.commands.errors.CheckFailure(f'The check functions for command {ctx.command} failed.')
     @is_staff("HalfOP")
     @commands.guild_only()
     @commands.command()

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -55,41 +55,42 @@ class Mod(DatabaseCog):
         
         if user is None:
             user = ctx.author
-        if (ctx.channel == self.bot.channels["bot-cmds"] and ctx.author == user) or await check_staff_id(ctx, 'Helper', ctx.author.id):
-                                
-            embed = discord.Embed(color=utils.gen_color(user.id))
-            embed.description = (
-                f"**User:** {user.mention}\n"
-                f"**User's ID:** {user.id}\n"
-                f"**Created on:** {user.created_at}\n"
-                f"**Default Profile Picture:** {user.default_avatar}\n"
+
+        if (not await check_staff_id(ctx, 'Helper', ctx.author.id)) and (ctx.author != user or ctx.channel != self.bot.channels['bot-cmds']):
+            await ctx.message.delete()
+            return await ctx.send(f"{ctx.author.mention} This command can only be used in {self.bot.channels['bot-cmds'].mention} and only on yourself.", delete_after=10)
+
+        embed = discord.Embed(color=utils.gen_color(user.id))
+        embed.description = (
+            f"**User:** {user.mention}\n"
+            f"**User's ID:** {user.id}\n"
+            f"**Created on:** {user.created_at}\n"
+            f"**Default Profile Picture:** {user.default_avatar}\n"
+        )
+
+        if isinstance(user, discord.Member):
+            member_type = "member"
+            embed.description += (
+                f"**Join date:** {user.joined_at}\n"
+                f"**Current Status:** {user.status}\n"
+                f"**User Activity:**: {user.activity}\n"
+                f"**Current Display Name:** {user.display_name}\n"
+                f"**Nitro Boost Info:** {user.premium_since}\n"
+                f"**Current Top Role:** {user.top_role}\n"
+                f"**Color:** {user.color}\n"
             )
-
-            if isinstance(user, discord.Member):
-                member_type = "member"
-                embed.description += (
-                    f"**Join date:** {user.joined_at}\n"
-                    f"**Current Status:** {user.status}\n"
-                    f"**User Activity:**: {user.activity}\n"
-                    f"**Current Display Name:** {user.display_name}\n"
-                    f"**Nitro Boost Info:** {user.premium_since}\n"
-                    f"**Current Top Role:** {user.top_role}\n"
-                    f"**Color:** {user.color}\n"
-                )
-            else:
-                member_type = "user"
-                try:
-                    ban = await ctx.guild.fetch_ban(user)
-                    embed.description += f"\n**Banned**, reason: {ban.reason}"
-                except discord.NotFound:
-                    pass
-
-            member_type = member_type if not user.bot else "bot"
-            embed.title = f"**Userinfo for {member_type} {user}**"
-            embed.set_thumbnail(url=user.avatar_url_as(static_format='png'))
-            await ctx.send(embed=embed)
         else:
-            raise discord.ext.commands.errors.CheckFailure(f'The check functions for command {ctx.command} failed.')
+            member_type = "user"
+            try:
+                ban = await ctx.guild.fetch_ban(user)
+                embed.description += f"\n**Banned**, reason: {ban.reason}"
+            except discord.NotFound:
+                pass
+
+        member_type = member_type if not user.bot else "bot"
+        embed.title = f"**Userinfo for {member_type} {user}**"
+        embed.set_thumbnail(url=user.avatar_url_as(static_format='png'))
+        await ctx.send(embed=embed)
 
     @is_staff("HalfOP")
     @commands.guild_only()


### PR DESCRIPTION
Allow userinfo2 to be used by everyone on themselves in #bot-cmds (can someone test this change as I am not 100% sure it works)

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->