### PR TITLE
Mention hardware modification solution for Mariko units

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -119,7 +119,8 @@ class SwitchSerialNumberCheck(Cog):
 
         if mariko:
             return await ctx.send("{}: Serial {} seems to be a \"mariko\" Switch or Switch Lite.\n" 
-                                  "These are currently not hackable or vulnerable to any known exploits".format(ctx.author.mention, safe_serial))
+                                  "Currently, These units can only be hacked by hardware modification solution proposed by Team Xecuter.\n"
+                                  "Please reminder: NO SUPPORT will be provided for Team Xecuter software and devices in this server.".format(ctx.author.mention, safe_serial))
         elif maybe:
             return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
                                   "pushing the payload manually. You can find instructions to do so here: "

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -118,9 +118,8 @@ class SwitchSerialNumberCheck(Cog):
             maybe = True
 
         if mariko:
-            return await ctx.send("{}: Serial {} seems to be a \"mariko\" Switch or Switch Lite.\n" 
-                                  "Currently, These units can only be hacked by hardware modification solution proposed by Team Xecuter.\n"
-                                  "Please reminder: NO SUPPORT will be provided for Team Xecuter software and devices in this server.".format(ctx.author.mention, safe_serial))
+            return await ctx.send("{}: Serial {} seems to be a \"mariko\" Switch or Switch Lite.\n"
+                                  "These are currently not hackable via software, only hardware modifications that involve soldering modchips.".format(ctx.author.mention, safe_serial))
         elif maybe:
             return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
                                   "pushing the payload manually. You can find instructions to do so here: "


### PR DESCRIPTION
Notice users that Mariko units and Lite units now can be hacked with hardware modification solution.

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->