### PR TITLE
Fix Inverted Quotation Mark in .sdroot

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1176,7 +1176,7 @@ NAND backups, and SD card contents. Windows, macOS, and Linux are supported.
     async def sdroot(self, ctx):
         """Picture to say what the heck is the root"""
         embed = discord.Embed()
-        embed.set_image(url="https://i.imgur.com/7PIvVjJ.png")
+        embed.set_image(url="https://i.imgur.com/QXHIvOz.jpg")
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['whatsid0', 'id0'])


### PR DESCRIPTION
For whatever reason, `.sdroot` has messed up quotation marks, though I guess that's how they do it in German. The problem is that the text in the picture is written in English and not German, so having it like this („…“) isn't right. Flump was kind enough and adjusted it so it's correct in the English language ("...").