### PR TITLE
Update for SD Format tip - missed dosfstools

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -570,7 +570,7 @@ re-read the guide steps 2 or 3 times before coming here.
     SDFORMAT_TEXT = """
                 Here are some links to common FAT32 formatting tools:
                 • [GUIFormat](http://www.ridgecrop.demon.co.uk/index.htm?guiformat.htm) (Windows)
-                • [gparted](https://gparted.org/download.php) (Linux)
+                • [gparted](https://gparted.org/download.php) + [dosfstools](https://github.com/dosfstools/dosfstools) (Linux)
                 • [Disk Utility](https://support.apple.com/guide/disk-utility/format-a-disk-for-windows-computers-dskutl1010) (MacOS)
                 MacOS: Always select "MS-DOS (FAT)", even if the card is larger than 32GB."""
 


### PR DESCRIPTION
This is a small update to the help given for formatting SD card - gparted alone is not enough and dosfstools must be installed in order to do formatting to FAT32