### PR TITLE
Add new "ready" command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -49,7 +49,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
 
     @check_if_user_can_ready()
     @commands.guild_only()
-    @commands.command(aliases=["ready"], cooldown=commands.Cooldown(rate=1, per=60.0, type=commands.BucketType.channel))
+    @commands.command(aliases=["ready"], cooldown=commands.Cooldown(rate=1, per=120.0, type=commands.BucketType.channel))
     async def ncready(self, ctx):
         """Alerts online staff to a ready request in newcomers."""
         author = ctx.author

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -2,7 +2,7 @@ import aiohttp
 import discord
 import urllib.parse
 
-from utils.checks import check_if_user_can_sr
+from utils.checks import check_if_user_can_sr, check_if_user_can_ready
 from discord.ext import commands
 from inspect import cleandoc
 
@@ -36,7 +36,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
         author = ctx.author
         await ctx.message.delete()
         # await ctx.send("Request sent.")
-        msg = f"❗️ **Assistance requested**: {ctx.channel.mention} by {author.mention} | {str(author)} @here"
+        msg = f"❗️ **Assistance requested**: {ctx.channel.mention} by {author.mention} | {self.bot.escape_text(author)} @here"
         if msg_request != "":
             # msg += "\n✏️ __Additional text__: " + msg_request
             embed = discord.Embed(color=discord.Color.gold())
@@ -44,6 +44,21 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
         await self.bot.channels['mods'].send(msg, embed=(embed if msg_request != "" else None))
         try:
             await author.send(f"✅ Online staff have been notified of your request in {ctx.channel.mention}.", embed=(embed if msg_request != "" else None))
+        except discord.errors.Forbidden:
+            pass
+
+    @check_if_user_can_ready()
+    @commands.guild_only()
+    @commands.command(aliases=["ready"], cooldown=commands.Cooldown(rate=1, per=60.0, type=commands.BucketType.channel))
+    async def ncready(self, ctx):
+        """Alerts online staff to a ready request in newcomers."""
+        author = ctx.author
+        await ctx.message.delete()
+
+        msg = f"❗️ **User ready in newcomers**: {ctx.channel.mention} by {author.mention} | {self.bot.escape_text(author)} @here"
+        await self.bot.channels['helpers'].send(msg)
+        try:
+            await author.send(f"✅ Online staff have been notified of your request.")
         except discord.errors.Forbidden:
             pass
 

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -58,7 +58,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
         msg = f"❗️ **User ready in newcomers**: {ctx.channel.mention} by {author.mention} | {self.bot.escape_text(author)} @here"
         await self.bot.channels['helpers'].send(msg)
         try:
-            await author.send(f"✅ Online staff have been notified of your request.")
+            await author.send("✅ Online staff have been notified of your request.")
         except discord.errors.Forbidden:
             pass
 

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -55,8 +55,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
         author = ctx.author
         await ctx.message.delete()
 
-        msg = f"❗️ **User ready in newcomers**: {ctx.channel.mention} by {author.mention} | {self.bot.escape_text(author)} @here"
-        await self.bot.channels['helpers'].send(msg)
+        await self.bot.channels['newcomers'].send('A user is ready for unprobation. @here')
         try:
             await author.send("✅ Online staff have been notified of your request.")
         except discord.errors.Forbidden:

--- a/kurisu.py
+++ b/kurisu.py
@@ -138,6 +138,7 @@ class Kurisu(commands.Bot):
             'server-logs': None,
             'bot-err': None,
             'elsewhere': None,  # I'm a bit worried about how often this changes, shouldn't be a problem tho
+            'newcomers': None,
         }
 
         self.failed_cogs = []

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -55,7 +55,7 @@ def check_if_user_can_sr():
 def check_if_user_can_ready():
     async def predicate(ctx):
         channel = ctx.channel
-        if not channel == ctx.bot.channels['newcomers']:
+        if channel != ctx.bot.channels['newcomers']:
             return False
         return True
     return commands.check(predicate)

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -44,7 +44,6 @@ async def check_bot_or_staff(ctx, target: discord.user, action: str):
 
     return await ctx.send(f"You can't {action} {who} with this command!")
 
-
 def check_if_user_can_sr():
     async def predicate(ctx):
         author = ctx.author
@@ -52,3 +51,12 @@ def check_if_user_can_sr():
             return False
         return True
     return commands.check(predicate)
+
+def check_if_user_can_ready():
+    async def predicate(ctx):
+        channel = ctx.channel
+        if not channel == ctx.bot.channels['newcomers']:
+            return False
+        return True
+    return commands.check(predicate)
+


### PR DESCRIPTION
This PR adds a command which will allow users in newcomers to request assistance from staff members without needing to resort to `@here` or `@everyone`, which reduces possibility of abuse due to a long cooldown.

It also edits `.ready`'s sister command, `.sr` to escape the author's name to avoid exploiting possible at-everyone or at-here pings by users who can access that command.
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->