### PR TITLE
Change output from .hbl command to be up-to-date

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -532,7 +532,7 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
                                 It is now recommended to use a CFW method like unSAFE_MODE
                                 to get Homebrew Launcher access, as these methods are simple and have a wider
                                 compatability with existing homebrew apps than HBL-only exploits.
-                                Use the ".guide 3ds" command to get a link to the recommended guide.
+                                Use the `.guide 3ds` command to get a link to the recommended guide.
                                 """)
 
     @commands.command()

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -529,11 +529,10 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
     async def hbl(self, ctx):
         """Get Homebrew Launcher working on 11.4+ firmware"""
         await self.simple_embed(ctx, """
-                                If you wish to access the Homebrew Launcher on 11.4+, you have two options.
-                                First of all, you can use Steelminer, a free exploit to install the Homebrew Launcher. However, homebrew-only access has disadvantages.
-                                For example, homebrew-only is often unstable and will crash unexpectedly. Also, it is limited in features and system access.
-                                The second option is to install CFW, or custom firmware. Please use `.guide 3ds` for a list of ways to get CFW.
-                                Here is a [Steelhax guide](https://git.io/fhbGY). Do NOT proceed to `Installing boot9strap` if you do not want CFW.
+                                It is now recommended to use a CFW method like unSAFE_MODE
+                                to get Homebrew Launcher access, as these methods are simple and have a wider
+                                compatability with existing homebrew apps than HBL-only exploits.
+                                Use the ".guide 3ds" command to get a link to the recommended guide.
                                 """)
 
     @commands.command()

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -527,7 +527,7 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
 
     @commands.command()
     async def hbl(self, ctx):
-        """Get Homebrew Launcher working on 11.4+ firmware"""
+        """Show recommended way to get access to the Homebrew Launcher on the latest firmware"""
         await self.simple_embed(ctx, """
                                 It is now recommended to use a CFW method like unSAFE_MODE
                                 to get Homebrew Launcher access, as these methods are simple and have a wider

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -527,12 +527,15 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
 
     @commands.command()
     async def hbl(self, ctx):
-        """Show recommended way to get access to the Homebrew Launcher on the latest firmware"""
+        """Show recommended ways to get access to the Homebrew Launcher"""
         await self.simple_embed(ctx, """
-                                It is now recommended to use a CFW method like unSAFE_MODE
-                                to get Homebrew Launcher access, as these methods are simple and have a wider
-                                compatability with existing homebrew apps than HBL-only exploits.
-                                Use the `.guide 3ds` command to get a link to the recommended guide.
+                                If you wish to access the Homebrew Launcher, you have two options.
+                                You could use Pichaxx, a free exploit to access the Homebrew Launcher.
+                                However, homebrew-only access has disadvantages.
+                                For example, homebrew-only is often unstable and will crash unexpectedly. Also, it is limited in features and system access.
+                                To use Pichaxx, follow [this](https://3ds.hacks.guide/seedminer.html) guide to get your console's movable.sed, \
+then [this](https://3ds.hacks.guide/homebrew-launcher-(pichaxx).html) guide to setup Pichaxx. Do not continue to Frogtool if you want homebrew-only access.
+                                Another option is to install Custom Firmware, or CFW. Use `.guide 3ds` for an up-to-date guide to install CFW.
                                 """)
 
     @commands.command()

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -530,7 +530,7 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
         """Show recommended ways to get access to the Homebrew Launcher"""
         await self.simple_embed(ctx, """
                                 If you wish to access the Homebrew Launcher, you have two options.
-                                You could use Pichaxx, a free exploit to access the Homebrew Launcher.
+                                You can use Pichaxx, a free exploit to access the Homebrew Launcher.
                                 However, homebrew-only access has disadvantages.
                                 For example, homebrew-only is often unstable and will crash unexpectedly. Also, it is limited in features and system access.
                                 To use Pichaxx, follow [this](https://3ds.hacks.guide/seedminer.html) guide to get your console's movable.sed, \


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->
The .hbl command previously recommended Steelhax, which should not really be used anymore. I updated it to only include CFW methods, as they are just about as easy as homebrew only methods, and have wider compatibility with existing homebrew apps.