### PR TITLE
Change .baninfo nx icon

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -524,7 +524,7 @@ and helpers can be found in #welcome-and-rules if you don't know who they are.
 
         elif self.check_console(console, ctx.message.channel.name, ('nx', 'switch', 'ns')):
             embed = discord.Embed(title="NX Bans", color=discord.Color.purple())
-            embed.set_thumbnail(url="https://eiphax.tech/assets/gunther.png")
+            embed.set_thumbnail(url="https://avatars1.githubusercontent.com/u/57876849?s=400&v=4")
             embed.url = "https://nx.eiphax.tech/ban"
             embed.description = "Bans on the Switch are complicated. Please click the embed header link and read the linked page to learn more."
             await ctx.send(embed=embed)


### PR DESCRIPTION
Changed my icon in the .baninfo nx embed to the one from my Github profile

<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->