### PR TITLE
Update Wii U .vc to Include UWUVCI AIO

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -904,19 +904,12 @@ are not on 11.3, use [this version of safehax.](https://github.com/TiniVi/safeha
                 continue
 
             if self.check_console(x, ctx.channel.name, ('wiiu', 'wii u')):
-                embed1 = discord.Embed(title="Wii and GameCube games for WiiU", color=discord.Color.red())
-                embed1.set_author(name="TeconMoon")
-                embed1.set_thumbnail(url="https://gbatemp.net/data/avatars/m/300/300039.jpg")
-                embed1.url = "https://gbatemp.net/threads/release-wiivc-injector-script-gc-wii-homebrew-support.483577/"
-                embed1.description = "The recommended way to play Wii and gamecube games on your WiiU"
-                await ctx.send(embed=embed1)
-
-                embed2 = discord.Embed(title="Virtual Console Injects for WiiU", color=discord.Color.red())
-                embed2.set_author(name="CatmanFan")
-                embed2.set_thumbnail(url="https://gbatemp.net/data/avatars/m/398/398221.jpg")
-                embed2.url = "https://gbatemp.net/threads/release-injectiine-wii-u-virtual-console-injector.491386/"
-                embed2.description = "The recommended way to play old classics on your WiiU"
-                await ctx.send(embed=embed2)
+                embed1 = discord.Embed(title="Classic Games for Wii U", color=discord.Color.red())
+                embed1.set_author(name="UWUVCI AIO")
+                embed1.set_thumbnail(url="https://gbatemp.net/data/avatars/l/404/404553.jpg")
+                embed1.url = "https://gbatemp.net/threads/release-uwuvci-injectiine.486781/"
+                embed1.description = "The recommended way to play classic games on your Wii U"
+                await ctx.send(embed=embed)
 
     # Embed to Console Dump Guides
     @commands.guild_only()

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -904,11 +904,11 @@ are not on 11.3, use [this version of safehax.](https://github.com/TiniVi/safeha
                 continue
 
             if self.check_console(x, ctx.channel.name, ('wiiu', 'wii u')):
-                embed1 = discord.Embed(title="Classic Games for Wii U", color=discord.Color.red())
-                embed1.set_author(name="UWUVCI AIO")
-                embed1.set_thumbnail(url="https://gbatemp.net/data/avatars/l/404/404553.jpg")
-                embed1.url = "https://gbatemp.net/threads/release-uwuvci-injectiine.486781/"
-                embed1.description = "The recommended way to play classic games on your Wii U"
+                embed = discord.Embed(title="Classic Games for Wii U", color=discord.Color.red())
+                embed.set_author(name="UWUVCI AIO")
+                embed.set_thumbnail(url="https://gbatemp.net/data/avatars/l/404/404553.jpg")
+                embed.url = "https://gbatemp.net/threads/release-uwuvci-injectiine.486781/"
+                embed.description = "The recommended way to play classic games on your Wii U"
                 await ctx.send(embed=embed)
 
     # Embed to Console Dump Guides


### PR DESCRIPTION
A new injector has been made for the Wii U which makes it easier for users to inject custom Virtual Console games to their Wii U (including but not limited to NES, SNES, N64, GCN, GBA, and Wii titles). A bunch of other features are included with the injector as well to make the process easier and more customizable of sorts, and with the developer's permission, it seems to be ready to include as the new, recommended option for the `.vc` command for Wii U.