### PR TITLE
Adjusting Wii U .vc Embed Some More

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -894,7 +894,7 @@ are not on 11.3, use [this version of safehax.](https://github.com/TiniVi/safeha
                 return
         for x in consoleslist:
             if self.check_console(x, ctx.channel.name, ('3ds',)):
-                embed = discord.Embed(title="Virtual Console Injects for 3DS", color=discord.Color.blue())
+                embed = discord.Embed(title="Virtual Console Injects for 3DS", color=discord.Color(0x009AC7))
                 embed.set_author(name="Asdolo", url="https://gbatemp.net/members/asdolo.389539/")
                 embed.set_thumbnail(url="https://i.imgur.com/rHa76XM.png")
                 embed.url = "https://mega.nz/#!qnAE1YjC!q3FRHgIAVEo4nRI2IfANHJr-r7Sil3YpPYE4w8ZbUPY"
@@ -904,11 +904,12 @@ are not on 11.3, use [this version of safehax.](https://github.com/TiniVi/safeha
                 continue
 
             if self.check_console(x, ctx.channel.name, ('wiiu', 'wii u')):
-                embed = discord.Embed(title="Classic Games for Wii U", color=discord.Color.red())
-                embed.set_author(name="UWUVCI AIO")
+                embed = discord.Embed(title="Classic Games for Wii U", color=discord.Color(0x66FFFF))
+                embed.set_author(name="NicoAICP",  url="https://gbatemp.net/members/nicoaicp.404553/")
                 embed.set_thumbnail(url="https://gbatemp.net/data/avatars/l/404/404553.jpg")
                 embed.url = "https://gbatemp.net/threads/release-uwuvci-injectiine.486781/"
-                embed.description = "The recommended way to play classic games on your Wii U"
+                embed.description = ("The recommended way to play old classics on your Wii U.\n"
+                                    "Usage guide [here](https://flumpster.github.io/instructions/index)")
                 await ctx.send(embed=embed)
 
     # Embed to Console Dump Guides

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -894,22 +894,22 @@ are not on 11.3, use [this version of safehax.](https://github.com/TiniVi/safeha
                 return
         for x in consoleslist:
             if self.check_console(x, ctx.channel.name, ('3ds',)):
-                embed = discord.Embed(title="Virtual Console Injects for 3DS", color=discord.Color(0x009AC7))
+                embed = discord.Embed(title="Virtual Console Injects for 3DS", color=discord.Color.red())
                 embed.set_author(name="Asdolo", url="https://gbatemp.net/members/asdolo.389539/")
                 embed.set_thumbnail(url="https://i.imgur.com/rHa76XM.png")
                 embed.url = "https://mega.nz/#!qnAE1YjC!q3FRHgIAVEo4nRI2IfANHJr-r7Sil3YpPYE4w8ZbUPY"
                 embed.description = ("The recommended way to play old classics on your 3DS.\n"
-                                     "Usage guide [here](http://3ds.eiphax.tech/nsui.html)")
+                                     "Usage guide [here](http://3ds.eiphax.tech/nsui.html).")
                 await ctx.send(embed=embed)
                 continue
 
             if self.check_console(x, ctx.channel.name, ('wiiu', 'wii u')):
-                embed = discord.Embed(title="Classic Games for Wii U", color=discord.Color(0x66FFFF))
+                embed = discord.Embed(title="Virtual Console Injects for Wii U", color=discord.Color.blue())
                 embed.set_author(name="NicoAICP",  url="https://gbatemp.net/members/nicoaicp.404553/")
                 embed.set_thumbnail(url="https://gbatemp.net/data/avatars/l/404/404553.jpg")
                 embed.url = "https://gbatemp.net/threads/release-uwuvci-injectiine.486781/"
                 embed.description = ("The recommended way to play old classics on your Wii U.\n"
-                                    "Usage guide [here](https://flumpster.github.io/instructions/index)")
+                                    "Usage guide [here](https://flumpster.github.io/instructions/index).")
                 await ctx.send(embed=embed)
 
     # Embed to Console Dump Guides


### PR DESCRIPTION
Nothing major, and pretty minor really. These changes could have gone in the previous pull request but it's already been merged so here is this instead. I just swapped the colors between the two currently standing embeds so Nintendo 3DS's `.vc` embed is now red and Wii U's `.vc` embed is now blue, which matches the rest of the commands. I also changed Wii U's embed to look much more like the Nintendo 3DS one in a sense, with the author instead of the application title, and also included a usage guide. This has been tested already in case I broke something in the process somehow.