### PR TITLE
Ready: have the user specify a reason or explanation.

### DIFF
--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from utils.database import DatabaseCog
 from utils.checks import is_staff, check_if_user_can_ready
+import re
 
 class Newcomers(DatabaseCog):
     """
@@ -74,8 +75,11 @@ class Newcomers(DatabaseCog):
         """Alerts online staff to a ready request in newcomers."""
         newcomers = self.bot.channels['newcomers']
         reason = reason[:300] # truncate to 300 chars so kurisu doesn't send absurdly huge messages
+        reason = re.sub(r'[^\x20-\x7f]', r'', reason) # filter out characters that aren't printable ascii
+        reason = discord.utils.escape_mentions(reason) # remove all other mentions, in case escaping tricks are attempted
 
         await ctx.message.delete()
+
         if reason:
             await newcomers.send(f'{ctx.author} (ID: {ctx.author.id}) is ready for unprobation.\n\nMessage: `{reason}` @here', allowed_mentions=discord.AllowedMentions(everyone=True))
             try:

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -75,7 +75,7 @@ class Newcomers(DatabaseCog):
         """Alerts online staff to a ready request in newcomers."""
         newcomers = self.bot.channels['newcomers']
         reason = reason[:300] # truncate to 300 chars so kurisu doesn't send absurdly huge messages
-        reason = re.sub(r'[^\x20-\x7f]', r'', reason) # filter out characters that aren't printable ascii
+        reason = re.sub(r'[^\x20-\x7f]', r'', reason.replace('\\', '')) # filter out non-ascii and backslash
         reason = discord.utils.escape_mentions(reason) # remove all other mentions, in case escaping tricks are attempted
 
         await ctx.message.delete()

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -2,7 +2,6 @@ import discord
 from discord.ext import commands
 from utils.database import DatabaseCog
 from utils.checks import is_staff, check_if_user_can_ready
-import asyncio
 
 class Newcomers(DatabaseCog):
     """

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -70,29 +70,24 @@ class Newcomers(DatabaseCog):
 
     @check_if_user_can_ready()
     @commands.guild_only()
-    @commands.command(aliases=['ready'])
-    @commands.max_concurrency(1, commands.BucketType.channel)
+    @commands.command(aliases=['ready'], cooldown=commands.Cooldown(rate=1, per=300.0, type=commands.BucketType.channel))
     async def ncready(self, ctx, *, reason=""):
         """Alerts online staff to a ready request in newcomers."""
-        cooldown = 300
         newcomers = self.bot.channels['newcomers']
-        reason = reason[:500] # truncate to 500 chars so kurisu doesn't send absurdly huge messages
+        reason = reason[:300] # truncate to 300 chars so kurisu doesn't send absurdly huge messages
 
         await ctx.message.delete()
         if reason:
             await newcomers.send(f'{ctx.author} (ID: {ctx.author.id}) is ready for unprobation.\n\nMessage: `{reason}` @here', allowed_mentions=discord.AllowedMentions(everyone=True))
-            await newcomers.send(f'This command will be usable again in {cooldown} seconds.', delete_after=cooldown)
             try:
                 await ctx.author.send('✅ Online staff have been notified of your request.')
             except discord.errors.Forbidden:
                 pass
         else:
-            cooldown = 30
-            await newcomers.send(f'{ctx.author.mention}, please run this command again in {cooldown} seconds \
+            await newcomers.send(f'{ctx.author.mention}, please run this command again \
 with a brief message explaining your situation (e.g., `.ready hey guys, i was having trouble hacking my console`). \
 **Copying and pasting the example will not remove your probation.**')
-
-        await asyncio.sleep(cooldown)
+            ctx.command.reset_cooldown(ctx)
 
 def setup(bot):
     bot.add_cog(Newcomers(bot))

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -75,7 +75,7 @@ class Newcomers(DatabaseCog):
         """Alerts online staff to a ready request in newcomers."""
         newcomers = self.bot.channels['newcomers']
         reason = reason[:300] # truncate to 300 chars so kurisu doesn't send absurdly huge messages
-        reason = re.sub(r'[^\x20-\x7f]', r'', reason.replace('\\', '')) # filter out non-ascii and backslash
+        reason = re.sub(r'[^\x20-\x5b\x5d-\x7f]', r'', reason) # filter out non-ascii and backslash
         reason = discord.utils.escape_mentions(reason) # remove all other mentions, in case escaping tricks are attempted
 
         await ctx.message.delete()

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -88,7 +88,9 @@ class Newcomers(DatabaseCog):
                 pass
         else:
             cooldown = 30
-            await newcomers.send(f'{ctx.author.mention}, please run this command in {cooldown} seconds again with a brief message explaining your situation (e.g., `.ready hi all, i\'m having an issue with my 3ds.`) **Copying and pasting the example will not remove your probation.**')
+            await newcomers.send(f'{ctx.author.mention}, please run this command in {cooldown} seconds again \
+with a brief message explaining your situation (e.g., `.ready hi all, i\'m having an issue with my 3ds.`). \
+**Copying and pasting the example will not remove your probation.**')
 
         await asyncio.sleep(cooldown)
 

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -88,7 +88,7 @@ class Newcomers(DatabaseCog):
                 pass
         else:
             cooldown = 30
-            await newcomers.send(f'{ctx.author.mention}, please run this command in {cooldown} seconds again \
+            await newcomers.send(f'{ctx.author.mention}, please run this command again in {cooldown} seconds \
 with a brief message explaining your situation (e.g., `.ready hi all, i\'m having an issue with my 3ds.`). \
 **Copying and pasting the example will not remove your probation.**')
 

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -81,7 +81,7 @@ class Newcomers(DatabaseCog):
         await ctx.message.delete()
         if reason:
             await newcomers.send(f'{ctx.author} (ID: {ctx.author.id}) is ready for unprobation.\n\nMessage: `{reason}` @here', allowed_mentions=discord.AllowedMentions(everyone=True))
-            await newcomers.send(f'This command will be usable again in {cooldown} seconds.')
+            await newcomers.send(f'This command will be usable again in {cooldown} seconds.', delete_after=cooldown)
             try:
                 await ctx.author.send('✅ Online staff have been notified of your request.')
             except discord.errors.Forbidden:

--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -89,7 +89,7 @@ class Newcomers(DatabaseCog):
         else:
             cooldown = 30
             await newcomers.send(f'{ctx.author.mention}, please run this command again in {cooldown} seconds \
-with a brief message explaining your situation (e.g., `.ready hi all, i\'m having an issue with my 3ds.`). \
+with a brief message explaining your situation (e.g., `.ready hey guys, i was having trouble hacking my console`). \
 **Copying and pasting the example will not remove your probation.**')
 
         await asyncio.sleep(cooldown)

--- a/kurisu.py
+++ b/kurisu.py
@@ -284,6 +284,8 @@ class Kurisu(commands.Bot):
             error_paginator = self.format_error(msg)
             for page in error_paginator.pages:
                 await channel.send(page)
+        elif isinstance(exc, commands.MaxConcurrencyReached):
+            await ctx.send(f'{author.mention} `{command}` is still on cooldown. Please see the command\'s text for how long you have to wait.')
         else:
             if not isinstance(command, str):
                 command.reset_cooldown(ctx)

--- a/kurisu.py
+++ b/kurisu.py
@@ -284,8 +284,6 @@ class Kurisu(commands.Bot):
             error_paginator = self.format_error(msg)
             for page in error_paginator.pages:
                 await channel.send(page)
-        elif isinstance(exc, commands.MaxConcurrencyReached):
-            await ctx.send(f'{author.mention} `{command}` is still on cooldown. Please see the command\'s text for how long you have to wait.', delete_after=10)
         else:
             if not isinstance(command, str):
                 command.reset_cooldown(ctx)

--- a/kurisu.py
+++ b/kurisu.py
@@ -285,7 +285,7 @@ class Kurisu(commands.Bot):
             for page in error_paginator.pages:
                 await channel.send(page)
         elif isinstance(exc, commands.MaxConcurrencyReached):
-            await ctx.send(f'{author.mention} `{command}` is still on cooldown. Please see the command\'s text for how long you have to wait.')
+            await ctx.send(f'{author.mention} `{command}` is still on cooldown. Please see the command\'s text for how long you have to wait.', delete_after=10)
         else:
             if not isinstance(command, str):
                 command.reset_cooldown(ctx)


### PR DESCRIPTION
If none is provided, then they will be told to provide one, with example syntax. It also emphasizes that we will not remove people from probation who just copy and paste the example. The command will also truncate the reason to 300 characters so that kurisu doesn't end up repeating the entirety of a huge block of spam. Backslashes, attempted mentions and unicode characters are also filtered out.