### PR TITLE
Fix noseasonal ignoring parameters

### DIFF
--- a/cogs/seasonal.py
+++ b/cogs/seasonal.py
@@ -53,7 +53,7 @@ class Seasonal(commands.Cog):
         t = datetime.today()
         curr_time = f"{t.month}.{t.day}"
         for season_ in self.seasons:
-            if (mode == "remove" and season_ == target) or (target == None and curr_time in season_):
+            if (mode == "remove" and season_.emote_str == target) or (target == None and curr_time in season_):
                 season = season_
                 break
         else:

--- a/cogs/seasonal.py
+++ b/cogs/seasonal.py
@@ -53,7 +53,7 @@ class Seasonal(commands.Cog):
         t = datetime.today()
         curr_time = f"{t.month}.{t.day}"
         for season_ in self.seasons:
-            if (mode == "remove" and season_ == target) or curr_time in season_:
+            if (mode == "remove" and season_ == target) or (target == None and curr_time in season_):
                 season = season_
                 break
         else:


### PR DESCRIPTION
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->