### PR TITLE
remove /latest from ams release link

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -684,7 +684,7 @@ re-read the guide steps 2 or 3 times before coming here.
         embed = discord.Embed(title="Atmosphère", color=discord.Color.blue())
         embed.set_author(name="Atmosphère-NX Team", url="https://github.com/Atmosphere-NX")
         embed.set_thumbnail(url="https://avatars2.githubusercontent.com/u/37918415?s=200&v=4")
-        embed.url = "https://github.com/Atmosphere-NX/Atmosphere/releases/latest"
+        embed.url = "https://github.com/Atmosphere-NX/Atmosphere/releases"
         embed.description = "Link to Atmosphère latest release"
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
pre-releases don't get shown with /latest