### PR TITLE
11.14 update to ntrboot command

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,7 +1511,7 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/CxRwyUX.png"
+        imagelink = "https://i.imgur.com/ntUDbGh.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,7 +1511,7 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/kQVAipT.png"
+        imagelink = "https://i.imgur.com/fwsn8p3.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,7 +1511,7 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/fwsn8p3.png"
+        imagelink = "https://i.imgur.com/erAFK1W.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,10 +1511,11 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/362bH8k.png"
+        imagelink = "https://i.imgur.com/CxRwyUX.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)
+        embed.description = "To see an always up to date list of compatible flashcarts go to https://3ds.hacks.guide/ntrboot"
         await ctx.send(embed=embed)
 
     @commands.command(aliases=['injector'])

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,7 +1511,7 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/erAFK1W.png"
+        imagelink = "https://i.imgur.com/duMthYp.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1511,7 +1511,7 @@ in the scene.
 
     @commands.command(aliases=['ntrboot', 'ntrcartlist', 'ntrbootcartlist'])
     async def ntrcart(self, ctx):
-        imagelink = "https://i.imgur.com/ntUDbGh.png"
+        imagelink = "https://i.imgur.com/kQVAipT.png"
         title = "Which flashcarts work with NTRBoot?"
         embed = discord.Embed(title=title, color=discord.Color.default())
         embed.set_image(url=imagelink)


### PR DESCRIPTION
a simple update to the .ntrboot command in the assistance.py file for the Nintendo homebrew discord server. putting a more updated picture of compatible flashcards (as well as an easier to understand layout). i also added a description with a link to 3ds.hacks.guide/ntrboot so that people can go there to see a more full list of compatible (and incompatible) flashcards for ntrboot. it also helps with figuring out where to buy each flashcart since 3ds.hacks.guide has links on where to buy each flashcart.

Feel free to change the description below, or remove it entirely if need be

`1518` embed.description = "To see an always up to date list of compatible flashcarts go to https://3ds.hacks.guide/ntrboot"
<!--
* If adding words to the filter list in events.py, make sure all characters are lowercase and consist only of characters in Python [`string.printable`](https://docs.python.org/3/library/string.html).
-->