### PR TITLE
fix issue where auto-mutes dont remove roles

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -273,6 +273,7 @@ class Events(commands.Cog):
         # it can trigger it multiple times if I use >. it can't skip to a number so this should work
         if len(self.user_antispam[message.author.id]) == 6:
             await message.author.add_roles(self.bot.roles['Muted'])
+            await member.remove_roles(self.bot.roles['#elsewhere'], self.bot.roles['#art-discussion'])
             await crud.add_permanent_role(message.author.id, self.bot.roles['Muted'].id)
             msg_user = f"You were automatically muted for sending too many messages in a short period of time!\n\n" \
                        f"If you believe this was done in error, send a direct message to one of the staff in {self.bot.channels['welcome-and-rules'].mention}."

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -275,8 +275,8 @@ class Events(commands.Cog):
             await message.author.add_roles(self.bot.roles['Muted'])
             await message.author.remove_roles(self.bot.roles['#elsewhere'], self.bot.roles['#art-discussion'])
             await crud.add_permanent_role(message.author.id, self.bot.roles['Muted'].id)
-            msg_user = f"You were automatically muted for sending too many messages in a short period of time!\n\n" \
-                       f"If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
+            msg_user = "You were automatically muted for sending too many messages in a short period of time!\n\n" \
+                       "If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
             await utils.send_dm_message(message.author, msg_user)
             log_msg = f"🔇 **Auto-muted**: {message.author.mention} muted for spamming | {message.author}\n🗓 __Creation__: {message.author.created_at}\n🏷 __User ID__: {message.author.id}"
             embed = discord.Embed(title="Deleted messages", color=discord.Color.gold())
@@ -310,8 +310,8 @@ class Events(commands.Cog):
         if sum(user_mentions) > 6:
             await crud.add_permanent_role(message.author, self.bot.roles["Probation"].id)
             await message.author.add_roles(self.bot.roles['Probation'])
-            msg_user = f"You were automatically placed under probation for mentioning too many users in a short period of time!\n\n" \
-                       f"If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
+            msg_user = "You were automatically placed under probation for mentioning too many users in a short period of time!\n\n" \
+                       "If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
             await utils.send_dm_message(message.author, msg_user)
             log_msg = f"🚫 **Auto-probated**: {message.author.mention} probated for mass user mentions | {message.author}\n" \
                       f"🗓 __Creation__: {message.author.created_at}\n🏷 __User ID__: {message.author.id}"

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -273,7 +273,7 @@ class Events(commands.Cog):
         # it can trigger it multiple times if I use >. it can't skip to a number so this should work
         if len(self.user_antispam[message.author.id]) == 6:
             await message.author.add_roles(self.bot.roles['Muted'])
-            await member.remove_roles(self.bot.roles['#elsewhere'], self.bot.roles['#art-discussion'])
+            await message.author.remove_roles(self.bot.roles['#elsewhere'], self.bot.roles['#art-discussion'])
             await crud.add_permanent_role(message.author.id, self.bot.roles['Muted'].id)
             msg_user = f"You were automatically muted for sending too many messages in a short period of time!\n\n" \
                        f"If you believe this was done in error, send a direct message to one of the staff in {self.bot.channels['welcome-and-rules'].mention}."

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -276,7 +276,7 @@ class Events(commands.Cog):
             await message.author.remove_roles(self.bot.roles['#elsewhere'], self.bot.roles['#art-discussion'])
             await crud.add_permanent_role(message.author.id, self.bot.roles['Muted'].id)
             msg_user = f"You were automatically muted for sending too many messages in a short period of time!\n\n" \
-                       f"If you believe this was done in error, send a direct message to one of the staff in {self.bot.channels['welcome-and-rules'].mention}."
+                       f"If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
             await utils.send_dm_message(message.author, msg_user)
             log_msg = f"🔇 **Auto-muted**: {message.author.mention} muted for spamming | {message.author}\n🗓 __Creation__: {message.author.created_at}\n🏷 __User ID__: {message.author.id}"
             embed = discord.Embed(title="Deleted messages", color=discord.Color.gold())
@@ -311,7 +311,7 @@ class Events(commands.Cog):
             await crud.add_permanent_role(message.author, self.bot.roles["Probation"].id)
             await message.author.add_roles(self.bot.roles['Probation'])
             msg_user = f"You were automatically placed under probation for mentioning too many users in a short period of time!\n\n" \
-                       f"If you believe this was done in error, send a direct message to one of the staff in {self.bot.channels['welcome-and-rules'].mention}."
+                       f"If you believe this was done in error, send a direct message (DM) to <@!333857992170536961> to contact staff."
             await utils.send_dm_message(message.author, msg_user)
             log_msg = f"🚫 **Auto-probated**: {message.author.mention} probated for mass user mentions | {message.author}\n" \
                       f"🗓 __Creation__: {message.author.created_at}\n🏷 __User ID__: {message.author.id}"


### PR DESCRIPTION
automutes do not clear roles and because discord permissions are absolutely awful this means if somebody was to spam in elsewhere they'd get automuted but still be able to spam in elsewhere

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
