### PR TITLE
add case_insensitive, a continuation

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -31,7 +31,7 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.Cooldown(1, 
 
     @check_if_user_can_sr()
     @commands.guild_only()
-    @commands.command(aliases=["sr", "Sr", "sR", "SR"], cooldown=commands.Cooldown(0, 0, commands.BucketType.channel))
+    @commands.command(aliases=["sr"], cooldown=commands.Cooldown(0, 0, commands.BucketType.channel))
     async def staffreq(self, ctx, *, msg_request: str = ""):
         """Request staff, with optional additional text. Trusted, Helpers, Staff, Retired Staff, Verified only."""
         author = ctx.author

--- a/kurisu.py
+++ b/kurisu.py
@@ -402,7 +402,7 @@ def main():
 
     intents = discord.Intents(guilds=True, members=True, bans=True, messages=True)
 
-    bot = Kurisu(('.', '!'), description="Kurisu, the bot for Nintendo Homebrew!", allowed_mentions=discord.AllowedMentions(everyone=False, roles=False), commit=commit, branch=branch, intents=intents)
+    bot = Kurisu(('.', '!'), description="Kurisu, the bot for Nintendo Homebrew!", allowed_mentions=discord.AllowedMentions(everyone=False, roles=False), commit=commit, branch=branch, intents=intents, case_insensitive=True)
     bot.help_command = commands.DefaultHelpCommand(dm_help=None)
     print(f'Starting Kurisu on commit {commit} on branch {branch}')
     bot.load_cogs()


### PR DESCRIPTION
A continuation of #925.

The edits are the same (only two lines need changing), but I made a new fork.

I am unsure if a check for lowercase with the `.invite` command is really necessary. It would just add to the Discord moderating, as now one needs to make sure all the invites are lowercase. As all other commands are working, it might just make more sense to add a warning that "This command is case-sensitive!" or something.

Please let me know of any suggestions.