### PR TITLE
Redirect ndsforwarder tutorial to DS-Homebrew wiki instead

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -1261,8 +1261,8 @@ complete list of tutorials, send `.tutorial` to me in a DM.', delete_after=10)
     async def ndsforwarders(self, ctx):
         """Links to nds forwarders"""
         embed = discord.Embed(title="NDS Forwarder Guide", color=discord.Color.purple())
-        embed.set_thumbnail(url="https://avatars3.githubusercontent.com/u/16110127?s=400&v=4")
-        embed.url = "https://gbatemp.net/threads/nds-forwarder-cias-for-your-home-menu.426174/"
+        embed.set_thumbnail(url="https://avatars.githubusercontent.com/u/46971470?s=400&v=4")
+        embed.url = "https://wiki.ds-homebrew.com/ds-index/3ds-forwarders"
         embed.description = "Tutorial for NDS Forwarders"
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
This PR changes the `.tutorial ndsforwarders` command to use the DS-Homebrew wiki page instead of Robz's GBATemp post. 
https://wiki.ds-homebrew.com/ds-index/3ds-forwarders

This particular guide is now written to use @MechanicalDragon0687 's NDSForwarder program instead for easier forwarding.