### PR TITLE
ncready tweak

### DIFF
--- a/cogs/newcomers.py
+++ b/cogs/newcomers.py
@@ -72,7 +72,7 @@ class Newcomers(commands.Cog):
 
     @check_if_user_can_ready()
     @commands.guild_only()
-    @commands.command(aliases=['ready'], cooldown=commands.Cooldown(rate=1, per=300.0, type=commands.BucketType.channel))
+    @commands.command(aliases=['ready'], cooldown=commands.Cooldown(rate=1, per=300.0, type=commands.BucketType.member))
     async def ncready(self, ctx, *, reason=""):
         """Alerts online staff to a ready request in newcomers."""
         newcomers = self.bot.channels['newcomers']


### PR DESCRIPTION
This should make it so the cooldown is per member, so member1 will not hit cooldown because of member2 doing the command
