### PR TITLE
assistance.py: update emptysd

### DIFF
--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -858,7 +858,7 @@ the system can't check for an update.
     async def emptysd(self, ctx):
         """What to do if you delete all your SD card contents"""
         await self.simple_embed(ctx, """
-                                Please follow the directions on the 3DS Hacks Guide [Restoring CFW](https://3ds.hacks.guide/restoring-cfw) page.
+                                Please follow the directions on the 3DS Hacks Guide [Restoring / Updating CFW](https://3ds.hacks.guide/restoring-updating-cfw) page.
                                 """, color=ConsoleColor.n3ds())
 
     @commands.command()


### PR DESCRIPTION
Guide page changed, restore cfw is not restore-update-cfw

