### PR TITLE
Upgrades to Levenshtein Filter

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -38,7 +38,7 @@ class Events(commands.Cog):
     def levenshtein_search_word(self, triggers: str, message: str) -> List[str]:
         matches = []
         message = message[::-1]
-        #to_check = re.findall(r"((?:[\w0-9-]+\.?){2})\/", message)
+
         to_check = re.findall(r"([\w0-9-]+\.[\w0-9-]+)", message)
         triggers = [*triggers, *self.bot.levenshteinfilter.filter['whitelist']]
         if triggers:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -37,13 +37,17 @@ class Events(commands.Cog):
 
     def levenshtein_search_word(self, triggers: str, message: str) -> List[str]:
         matches = []
-        to_check = re.findall(r"https?:\/\/(www.)?([\w.-]+)", message)
+        message = message[::-1]
+        #to_check = re.findall(r"((?:[\w0-9-]+\.?){2})\/", message)
+        to_check = re.findall(r"([\w0-9-]+\.[\w0-9-]+)", message)
+        triggers = [*triggers, *self.bot.levenshteinfilter.filter['whitelist']]
         if triggers:
             allowed = list(zip(*triggers))[0]
         else:
             allowed = []
-        for _, word in to_check:
+        for word in to_check:
             for trigger, threshold in triggers:
+                word = word[::-1]
                 chance = distance(word, trigger)
                 if chance == 0 or word in allowed:
                     continue

--- a/cogs/filters.py
+++ b/cogs/filters.py
@@ -80,7 +80,7 @@ class Filter(commands.Cog):
         entry = await self.bot.levenshteinfilter.add(word=word, threshold=threshold, kind=kind)
         await self.bot.channels['mod-logs'].send(f"🆕 **Added**: {ctx.author.mention} added `{entry.word}` to the Levenshtein filter!")
         await ctx.send("Successfully added word to Levenshtein filter")
-    
+
     @is_staff("SuperOP")
     @levenshteinfilter.command(name='whitelist')
     async def whitelist_levenshtein(self, ctx, word: str):

--- a/cogs/filters.py
+++ b/cogs/filters.py
@@ -80,6 +80,18 @@ class Filter(commands.Cog):
         entry = await self.bot.levenshteinfilter.add(word=word, threshold=threshold, kind=kind)
         await self.bot.channels['mod-logs'].send(f"🆕 **Added**: {ctx.author.mention} added `{entry.word}` to the Levenshtein filter!")
         await ctx.send("Successfully added word to Levenshtein filter")
+    
+    @is_staff("SuperOP")
+    @levenshteinfilter.command(name='whitelist')
+    async def whitelist_levenshtein(self, ctx, word: str):
+        word = word.lower()
+        if ' ' in word or '-' in word:
+            return await ctx.send("Filtered words cant contain dashes or spaces!")
+        if await self.bot.levenshteinfilter.fetch_word(word):
+            return await ctx.send("This word is already in the filter!")
+        entry = await self.bot.levenshteinfilter.add(word=word, threshold=0, kind="whitelist")
+        await self.bot.channels['mod-logs'].send(f"🆕 **Added**: {ctx.author.mention} added `{entry.word}` to the Levenshtein filter's whitelist!")
+        await ctx.send("Successfully added word to Levenshtein whitelist")
 
     @levenshteinfilter.command(name='list')
     async def list_levenshtein(self, ctx):

--- a/utils/manager.py
+++ b/utils/manager.py
@@ -42,7 +42,7 @@ class WordFilterManager:
 
 class LevenshteinFilterManager:
     def __init__(self):
-        self.kinds = ('scamming site','whitelist')
+        self.kinds = ('scamming site', 'whitelist')
         self.filter = {}
 
     async def load(self):

--- a/utils/manager.py
+++ b/utils/manager.py
@@ -42,7 +42,7 @@ class WordFilterManager:
 
 class LevenshteinFilterManager:
     def __init__(self):
-        self.kinds = ('scamming site',)
+        self.kinds = ('scamming site','whitelist')
         self.filter = {}
 
     async def load(self):


### PR DESCRIPTION
This PR introduces a couple upgrades to the Levenshtein filter, namely

- The Levenshtein filter now is able to match scam links in far more cases, thanks to it pulling the last two labels out of domains name and testing them.
- The Levenshtein filter now has whitelist functionality to deal with threshold overlaps between domains (for example, `steamcommunity.com` with a threshold of 8 would block `steampowered.com`). This can be added to with `.levenshteinfilter whitelist steampowered.com` and removed from with `.levenshteinfilter delete steampowered.com`.

