### PR TITLE
events: discord.com/invite now filtered

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -118,7 +118,7 @@ class Events(commands.Cog):
         contains_video = any(res)
         contains_piracy_video_id = False if not contains_video else any(x for x in res if x in self.bot.wordfilter.filter['piracy video'])
 
-        res = re.findall(r'(?:discordapp\.com/invite|discord\.gg)/([\w]+)', message.content)
+        res = re.findall(r'(?:discordapp\.com/invite|discord\.gg|discord\.com/invite)/([\w]+)', message.content)
         approved_invites = [x for x in self.bot.invitefilter.invites if x.code in res]
         contains_non_approved_invite = len(res) != len(approved_invites)
 


### PR DESCRIPTION
An invite that was not filtered was posted and not autoremoved due to Kurisu not filtering `discord.com` specifically. This is fixed here and tested.