### PR TITLE
assistance: fix DSi guide links

### DIFF
--- a/cogs/assistance-cmds/guide.dsi.md
+++ b/cogs/assistance-cmds/guide.dsi.md
@@ -1,9 +1,8 @@
 ---
 title: Guide
-url: https://dsi.cfw.guide/credits
+url: https://dsi.cfw.guide/
 thumbnail-url: https://i.imgur.com/OGelKVt.png
 author.name: emiyl & DS⁽ⁱ⁾ Mode Hacking
-author.url: https://dsi.cfw.guide/
 help-desc: Links to the recommended guides.
 ---
 


### PR DESCRIPTION
See title.

Also... do we really want author-urls on all of these? Seems to be no point.
