### PR TITLE
extras: allow tags to be used with annotations

### DIFF
--- a/cogs/extras.py
+++ b/cogs/extras.py
@@ -290,7 +290,7 @@ class Extras(commands.Cog):
         await ctx.send("I will send you a reminder then.")
 
     @commands.group(invoke_without_command=True)
-    async def tag(self, ctx, *, title: str = ""):
+    async def tag(self, ctx, title: str = ""):
         if ctx.invoked_subcommand is None:
             if title:
                 if tag := await crud.get_tag(title):

--- a/cogs/extras.py
+++ b/cogs/extras.py
@@ -296,7 +296,7 @@ class Extras(commands.Cog):
                 if tag := await crud.get_tag(title):
                     return await ctx.send(tag.content)
                 else:
-                    await ctx.send("This tag doesn't exists!")
+                    await ctx.send("This tag doesn't exist!")
             else:
                 await ctx.send_help(ctx.command)
 


### PR DESCRIPTION
If one were to say:
`.tag cfwcheck please go here to check your console for cfw` this tries to search all of `cfwcheck please go here to check your console for cfw`

This PR:
- Only searches the first argument so that tags can be used with extra comments, which is used very frequently with all other assistance commands.
- Fixes tag search error typo. ~~Now the typo doesn't exists!~~