### PR TITLE
kickban: fix scamban filter search

### DIFF
--- a/cogs/kickban.py
+++ b/cogs/kickban.py
@@ -242,7 +242,7 @@ class KickBan(commands.Cog):
     @commands.command(name="scamban")
     async def scamban_member(self, ctx, member: discord.Member, site: str):
         """Bans member deleting message from last day and add a scamming site to the filter"""
-        if site in self.bot.wordfilter['scamming site']:
+        if site in self.bot.wordfilter.filter['scamming site']:
             await ctx.send("Site is already in the filter!")
         elif ' ' in site or '-' in site:
             await ctx.send("Filtered words can't contain dashes or spaces, please add the site properly with wordfilter command.")


### PR DESCRIPTION
Wordfilter search is `self.bot.wordfilter.filter[query]` and not `self.bot.wordfilter[query]`, which caused scamban to fail. This is fixed here. Tested on a server template.