### PR TITLE
Remove unnecessary condition

### DIFF
--- a/cogs/assistance-cmds/newver.switch.md
+++ b/cogs/assistance-cmds/newver.switch.md
@@ -5,10 +5,10 @@ help-desc: Quick advice for new versions
 
 Currently, the latest Switch system firmware is `{nx_firmware}`.
 
-If your Switch is **unpatched and can access RCM**:
+If your Switch is **unpatched**:
 Atmosphere and Hekate **DO NOT** currently support {nx_firmware}, and unpatched units will always be hackable, you will just have to wait until AMS and Hekate update.
 You should follow the precautions in our update guide, and always update Atmosphere and Hekate before updating the system firmware.
 
-If your Switch is **hardware patched and cannot access RCM**:
+If your Switch is **hardware patched**:
 Stay on the lowest possible firmware version. Any Switch that is patched and above 7.0.1 is unlikely to be hackable.
 *Last edited: {last_revision}*


### PR DESCRIPTION
"can access RCM" and "cannot access RCM" in newver nx are both incorrect (patched switches can still access RCM) and unnecessary   