### PR TITLE
Add OLED

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -45,7 +45,7 @@ class SwitchSerialNumberCheck(Cog):
             # XKW10000000000, XKJ10000000000 = HAC-001-01, the "New Switch"
             # XJW01000000000, XWW01000000000 = HDH-001, the Switch Lite
             # As not much about the assembly line is known yet every digit will count for the filter
-            if re.match("X[KJW][JWC][0-9]{7}", serial):
+            if re.match("X[KJWT][JWC][0-9]{7}", serial):
                 # Region "C" is Tencent-Nintendo Switch. Mariko.
                 mariko = True
             else:


### PR DESCRIPTION
OLED Switches use the letter T and are also not hackable via software

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
