### PR TITLE
Reset cooldown if missing required argument

### DIFF
--- a/kurisu.py
+++ b/kurisu.py
@@ -368,6 +368,7 @@ class Kurisu(commands.Bot):
         elif isinstance(exc, commands.MissingRequiredArgument):
             await ctx.send(f'{author.mention} You are missing required argument {exc.param.name}.\n')
             await ctx.send_help(ctx.command)
+            command.reset_cooldown(ctx)
 
         elif isinstance(exc, discord.NotFound):
             await ctx.send("ID not found.")


### PR DESCRIPTION
Mainly useful for nickme due to how long the cooldown is but this change would also apply to all other commands.
I think it's unlikely that this could be abused, but I haven't properly checked so it's possible I missed something.