### PR TITLE
90dns and missingconfig

### DIFF
--- a/cogs/assistance-cmds/90dns.switch.md
+++ b/cogs/assistance-cmds/90dns.switch.md
@@ -1,9 +1,13 @@
 ---
-title: DNS.mitm and 90DNS
-help-desc: Applying 90DNS protection
-aliases: dnsmitm
+title: 90DNS IP addresses
+help-desc: 90DNS IP addresses
+aliases: ninetydns
 ---
 
-To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection)
+The public 90DNS IP addresses are:
+- `207.246.121.77` (USA)
+- `163.172.141.219`(France)
 
-[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and redirect requests to Nintendo servers blocked by 90DNS
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up 90dns and ensure it isn't being blocked
+
+You will have to manually set these for each WiFi connection you have set up.

--- a/cogs/assistance-cmds/90dns.switch.md
+++ b/cogs/assistance-cmds/90dns.switch.md
@@ -1,13 +1,9 @@
 ---
-title: 90DNS IP addresses
-help-desc: 90DNS IP addresses
-aliases: ninetydns
+title: DNS.mitm and 90DNS
+help-desc: Applying 90DNS protection
+aliases: dnsmitm
 ---
 
-The public 90DNS IP addresses are:
-- `207.246.121.77` (USA)
-- `163.172.141.219`(France)
+To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection)
 
-[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up 90dns and ensure it isn't being blocked
-
-You will have to manually set these for each WiFi connection you have set up.
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and redirect requests to Nintendo servers blocked by 90DNS

--- a/cogs/assistance-cmds/90dns.switch.md
+++ b/cogs/assistance-cmds/90dns.switch.md
@@ -8,6 +8,6 @@ The public 90DNS IP addresses are:
 - `207.246.121.77` (USA)
 - `163.172.141.219`(France)
 
-[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up 90dns and ensure it isn't being blocked
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_nintendo/) to set up 90dns and ensure it isn't being blocked
 
 You will have to manually set these for each WiFi connection you have set up.

--- a/cogs/assistance-cmds/dnsmitm.switch.md
+++ b/cogs/assistance-cmds/dnsmitm.switch.md
@@ -1,0 +1,8 @@
+---
+title: DNS.mitm
+help-desc: Applying AMS DNS redirection
+---
+
+To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection).
+
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and redirect requests to Nintendo.

--- a/cogs/assistance-cmds/dnsmitm.switch.md
+++ b/cogs/assistance-cmds/dnsmitm.switch.md
@@ -5,4 +5,4 @@ help-desc: Applying AMS DNS redirection
 
 To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection).
 
-[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and redirect requests to Nintendo.
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and automatically redirect any requests directed to Nintendo to nothing instead.

--- a/cogs/assistance-cmds/dnsmitm.switch.md
+++ b/cogs/assistance-cmds/dnsmitm.switch.md
@@ -5,4 +5,4 @@ help-desc: Applying AMS DNS redirection
 
 To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection).
 
-[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_updates/) to set up DNS.mitm on your emuMMC/emuNAND and automatically redirect any requests directed to Nintendo to nothing instead.
+[Follow these steps](https://nh-server.github.io/switch-guide/extras/blocking_nintendo/) to set up DNS.mitm on your emuMMC/emuNAND and automatically redirect any requests directed to Nintendo to nothing instead.

--- a/cogs/assistance-cmds/missingconfig.switch.md
+++ b/cogs/assistance-cmds/missingconfig.switch.md
@@ -1,9 +1,7 @@
 ---
-title: Getting the "No main boot entries found" error in hekate?
-help-desc: No main boot entries found solution
+title: Missing or wrong boot entries in hekate?
+help-desc: Getting the hekate_ipl.ini file from the guide
 aliases: missingco
 ---
 
-You forgot to copy the "hekate_ipl.ini" file to the bootloader folder on your sd card, or forgot to insert your sd card before booting hekate.
-
-Note that if hekate can't find a config, it'll create one. So likely you now have a hekate_ipl.ini in your bootloader folder, replace it with the one from [the guide](https://nh-server.github.io/switch-guide/user_guide/emummc/sd_preparation/)
+Your "hekate_ipl.ini" file is incorrect. You can download a new one [here](https://www.dropbox.com/s/kajvl1k696vvsod/hekate_ipl.ini?dl=1) to replace the one that is currently in your bootloader folder.

--- a/cogs/assistance-cmds/missingconfig.switch.md
+++ b/cogs/assistance-cmds/missingconfig.switch.md
@@ -4,4 +4,4 @@ help-desc: Getting the hekate_ipl.ini file from the guide
 aliases: missingco
 ---
 
-Your "hekate_ipl.ini" file is incorrect. You can download a new one [here](https://www.dropbox.com/s/kajvl1k696vvsod/hekate_ipl.ini?dl=1) to replace the one that is currently in your bootloader folder.
+Your "hekate_ipl.ini" file should be updated. You can download a new one [here](https://www.dropbox.com/s/kajvl1k696vvsod/hekate_ipl.ini?dl=1) to replace the one that is currently in your bootloader folder.

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -18,10 +18,10 @@ class Assistance(commands.Cog, command_attrs=dict(cooldown=commands.CooldownMapp
     """
 
     format_map = {
-        'nx_firmware': '13.2.0',
-        'ams_ver': '1.2.4',
-        'hekate_ver': '5.6.5',
-        'last_revision': 'December 1st, 2021',
+        'nx_firmware': '13.2.1',
+        'ams_ver': '1.2.6',
+        'hekate_ver': '5.7.0',
+        'last_revision': 'January 20th, 2022',
     }
 
     # compatibility until the use of these variables is removed


### PR DESCRIPTION
Changed both 90dns and missingconfig switch assistance commands

### 90DNS
Removed the IP addresses to mention the preferred method (dns.mitm)

### missingconfig
Made it clear that you have to replace your hekate_ipl.ini by the one provided