### PR TITLE
`getstarted`: add the missing `.0`

### DIFF
--- a/cogs/assistance-cmds/getstarted.3ds.md
+++ b/cogs/assistance-cmds/getstarted.3ds.md
@@ -8,4 +8,4 @@ help-desc: Links the 3DS get-started page
 aliases: 3dslanding
 ---
 
-How to hack your 3DS console on any firmware from 1.0.0 to 11.15
+How to hack your 3DS console on any firmware from 1.0.0 to 11.15.0


### PR DESCRIPTION
This is a very important commit as this prevents lily's OCD from activating
