### PR TITLE
Replace dtm_to_discord_timestamp with format_dt

### DIFF
--- a/cogs/extras.py
+++ b/cogs/extras.py
@@ -13,10 +13,11 @@ import sys
 from discord import TextChannel, __version__ as discordpy_version
 from disnake.ext.commands import Param
 from discord.ext import commands
+from discord.utils import format_dt
 from typing import Union, TYPE_CHECKING
 from utils import crud, utils
 from utils.checks import is_staff, check_if_user_can_sr, check_staff_id
-from utils.utils import gen_color, dtm_to_discord_timestamp
+from utils.utils import gen_color
 
 if TYPE_CHECKING:
     from kurisu import Kurisu
@@ -370,7 +371,7 @@ class Extras(commands.Cog):
         delta = datetime.timedelta(seconds=remind_in)
         reminder_time = timestamp + delta
         await crud.add_reminder(reminder_time, ctx.author.id, reminder)
-        await ctx.send(f"I will send you a reminder on {dtm_to_discord_timestamp(reminder_time, date_format='F')}.")
+        await ctx.send(f"I will send you a reminder on {format_dt(reminder_time, style='F')}.")
 
     @commands.command()
     async def listreminders(self, ctx: commands.Context):
@@ -383,7 +384,7 @@ class Extras(commands.Cog):
         for n, reminder in enumerate(reminders, start=1):
             embed = discord.Embed(title=f"Reminder {n}", color=color)
             embed.add_field(name='Content', value=reminder.reminder, inline=False)
-            embed.add_field(name='Set to', value=utils.dtm_to_discord_timestamp(reminder.date), inline=False)
+            embed.add_field(name='Set to', value=format_dt(reminder.date), inline=False)
             embeds.append(embed)
         view = utils.PaginatedEmbedView(embeds, author=ctx.author)
         view.message = await ctx.send(embed=embeds[0], view=view)

--- a/cogs/kickban.py
+++ b/cogs/kickban.py
@@ -5,6 +5,7 @@ import datetime
 
 from discord.ext import commands
 from disnake.ext.commands import Param
+from discord.utils import format_dt
 from typing import Union, Literal, TYPE_CHECKING, Optional
 from utils import utils, crud
 from utils.checks import is_staff, check_bot_or_staff
@@ -110,7 +111,7 @@ class KickBan(commands.Cog):
             timestamp = datetime.datetime.now()
             delta = datetime.timedelta(seconds=duration)
             unban_time = timestamp + delta
-            unban_time_string = utils.dtm_to_discord_timestamp(unban_time)
+            unban_time_string = format_dt(unban_time)
 
             try:
                 await inter.guild.ban(member, reason=reason, delete_message_days=delete_messages)
@@ -230,7 +231,7 @@ class KickBan(commands.Cog):
         timestamp = datetime.datetime.now()
         delta = datetime.timedelta(seconds=length)
         unban_time = timestamp + delta
-        unban_time_string = utils.dtm_to_discord_timestamp(unban_time)
+        unban_time_string = format_dt(unban_time)
 
         if isinstance(member, discord.Member):
             msg = f"You were banned from {ctx.guild.name}."

--- a/cogs/logs.py
+++ b/cogs/logs.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import discord
 
 from discord.ext import commands
+from discord.utils import format_dt
 from typing import TYPE_CHECKING
 from utils import crud
-from utils.utils import send_dm_message, dtm_to_discord_timestamp
+from utils.utils import send_dm_message
 
 if TYPE_CHECKING:
     from kurisu import Kurisu
@@ -186,8 +187,8 @@ Thanks for stopping by and have a good time!
                 msg = "\n🚷 __Timeout removal__"
             else:
                 msg = "\n🚷 __Timeout change__"
-            timeout_before = dtm_to_discord_timestamp(member_before.current_timeout, utc_time=True) if member_before.current_timeout else 'None'
-            timeout_after = dtm_to_discord_timestamp(member_after.current_timeout, utc_time=True) if member_after.current_timeout else 'None'
+            timeout_before = format_dt(member_before.current_timeout) if member_before.current_timeout else 'None'
+            timeout_after = format_dt(member_after.current_timeout) if member_after.current_timeout else 'None'
             msg += f": {timeout_before} → {timeout_after}"
         if do_log:
             msg = f"ℹ️ **Member update**: {member_after.mention} | {self.bot.escape_text(member_after)} {msg}"

--- a/cogs/loop.py
+++ b/cogs/loop.py
@@ -8,9 +8,10 @@ import logging
 from datetime import datetime, timedelta
 from discord import AllowedMentions
 from discord.ext import commands
+from discord.utils import format_dt
 from typing import TYPE_CHECKING
 from utils import crud
-from utils.utils import send_dm_message, dtm_to_discord_timestamp
+from utils.utils import send_dm_message
 
 if TYPE_CHECKING:
     from kurisu import Kurisu
@@ -77,10 +78,10 @@ class Loop(commands.Cog):
                 end = datetime(year=2099, month=1, day=1, tzinfo=self.tz)
                 if "begin" in entry:
                     begin = self.netinfo_parse_time(entry["begin"])
-                    entry_desc += '\nBegins: ' + dtm_to_discord_timestamp(begin)
+                    entry_desc += '\nBegins: ' + format_dt(begin)
                 if "end" in entry:
                     end = self.netinfo_parse_time(entry["end"])
-                    entry_desc += '\nEnds: ' + dtm_to_discord_timestamp(end)
+                    entry_desc += '\nEnds: ' + format_dt(end)
 
                 if now < end:
                     entry_name = "{} {}: {}".format(

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -6,6 +6,7 @@ import re
 
 from disnake.ext.commands import Param
 from discord.ext import commands
+from discord.utils import format_dt
 from subprocess import call
 from typing import Union, Optional, TYPE_CHECKING
 from utils import utils, crud, models
@@ -76,18 +77,18 @@ class Mod(commands.Cog):
         embed.description = (
             f"**User:** {user.mention}\n"
             f"**User's ID:** {user.id}\n"
-            f"**Created on:** {utils.dtm_to_discord_timestamp(user.created_at, utc_time=True)} ({utils.dtm_to_discord_timestamp(user.created_at, date_format='R', utc_time=True)})\n"
+            f"**Created on:** {utils.format_dt(user.created_at)} ({format_dt(user.created_at, style='R')})\n"
             f"**Default Profile Picture:** {user.default_avatar}\n"
         )
 
         if isinstance(user, discord.Member):
             member_type = "member"
             embed.description += (
-                f"**Join date:** {utils.dtm_to_discord_timestamp(user.joined_at, utc_time=True)} ({utils.dtm_to_discord_timestamp(user.joined_at, date_format='R', utc_time=True)})\n"
+                f"**Join date:** {format_dt(user.joined_at)} ({format_dt(user.joined_at, style='R')})\n"
                 f"**Current Status:** {user.status}\n"
                 f"**User Activity:** {user.activity}\n"
                 f"**Current Display Name:** {user.display_name}\n"
-                f"**Nitro Boost Info:** {f'Boosting since {utils.dtm_to_discord_timestamp(user.premium_since, utc_time=True)}' if user.premium_since else 'Not a booster'}\n"
+                f"**Nitro Boost Info:** {f'Boosting since {format_dt(user.premium_since)}' if user.premium_since else 'Not a booster'}\n"
                 f"**Current Top Role:** {user.top_role}\n"
                 f"**Color:** {user.color}\n"
                 f"**Profile Picture:** [link]({user.avatar})"
@@ -115,17 +116,17 @@ class Mod(commands.Cog):
         embed.description = (
             f"**User:** {user.mention}\n"
             f"**User's ID:** {user.id}\n"
-            f"**Created on:** {utils.dtm_to_discord_timestamp(user.created_at, utc_time=True)} ({utils.dtm_to_discord_timestamp(user.created_at, date_format='R', utc_time=True)})\n"
+            f"**Created on:** {format_dt(user.created_at)} ({format_dt(user.created_at, style='R')})\n"
             f"**Default Profile Picture:** {user.default_avatar}\n"
         )
         if isinstance(user, discord.Member):
             member_type = "member"
             embed.description += (
-                f"**Join date:** {utils.dtm_to_discord_timestamp(user.joined_at, utc_time=True)} ({utils.dtm_to_discord_timestamp(user.joined_at, date_format='R', utc_time=True)})\n"
+                f"**Join date:** {format_dt(user.joined_at)} ({format_dt(user.joined_at, style='R')})\n"
                 f"**Current Status:** {user.status}\n"
                 f"**User Activity:** {user.activity}\n"
                 f"**Current Display Name:** {user.display_name}\n"
-                f"**Nitro Boost Info:** {f'Boosting since {utils.dtm_to_discord_timestamp(user.premium_since, utc_time=True)}' if user.premium_since else 'Not a booster'}\n"
+                f"**Nitro Boost Info:** {f'Boosting since {format_dt(user.premium_since)}' if user.premium_since else 'Not a booster'}\n"
                 f"**Current Top Role:** {user.top_role}\n"
                 f"**Color:** {user.color}\n"
                 f"**Profile Picture:** [link]({user.avatar.url})"
@@ -378,7 +379,7 @@ class Mod(commands.Cog):
         timestamp = datetime.datetime.now()
         delta = datetime.timedelta(seconds=length)
         unmute_time = timestamp + delta
-        unmute_time_string = utils.dtm_to_discord_timestamp(unmute_time)
+        unmute_time_string = format_dt(unmute_time)
 
         old_mute = await crud.get_time_restriction_by_user_type(member.id, 'timemute')
         await crud.add_timed_restriction(member.id, unmute_time, 'timemute')
@@ -394,7 +395,7 @@ class Mod(commands.Cog):
             msg = f"🔇 **Timed mute**: {issuer.mention} muted {member.mention}| {self.bot.escape_text(member)} for {delta}, until {unmute_time_string} "
         else:
             await ctx.send(f"{member.mention} mute was updated.")
-            msg = f"🔇 **Timed mute**: {issuer.mention} updated {member.mention}| {self.bot.escape_text(member)} time mute from {utils.dtm_to_discord_timestamp(old_mute.end_date)} until {unmute_time_string}"
+            msg = f"🔇 **Timed mute**: {issuer.mention} updated {member.mention}| {self.bot.escape_text(member)} time mute from {format_dt(old_mute.end_date)} until {unmute_time_string}"
         if reason != "":
             msg += "\n✏️ __Reason__: " + reason
         else:
@@ -428,7 +429,7 @@ class Mod(commands.Cog):
 
         issuer = ctx.author
         member = await member.timeout(duration=length, reason=reason)
-        timeout_expiration = utils.dtm_to_discord_timestamp(datetime.datetime.now() + datetime.timedelta(seconds=length))
+        timeout_expiration = format_dt(datetime.datetime.now() + datetime.timedelta(seconds=length))
 
         msg_user = "You were given a timeout!"
         if reason is not None:
@@ -627,7 +628,7 @@ class Mod(commands.Cog):
         timestamp = datetime.datetime.now()
 
         unnohelp_time = timestamp + delta
-        unnohelp_time_string = utils.dtm_to_discord_timestamp(unnohelp_time)
+        unnohelp_time_string = format_dt(unnohelp_time)
 
         await crud.add_timed_restriction(member.id, unnohelp_time, 'timenohelp')
         await crud.add_permanent_role(member.id, self.bot.roles['No-Help'].id)
@@ -708,7 +709,7 @@ class Mod(commands.Cog):
         timestamp = datetime.datetime.now()
 
         unnotech_time = timestamp + delta
-        unnotech_time_string = utils.dtm_to_discord_timestamp(unnotech_time)
+        unnotech_time_string = format_dt(unnotech_time)
 
         await crud.add_timed_restriction(member.id, unnotech_time, 'timenotech')
         await crud.add_permanent_role(member.id, self.bot.roles['No-Tech'].id)
@@ -769,7 +770,7 @@ class Mod(commands.Cog):
         timestamp = datetime.datetime.now()
 
         unhelpmute_time = timestamp + delta
-        unhelpmute_time_string = utils.dtm_to_discord_timestamp(unhelpmute_time)
+        unhelpmute_time_string = format_dt(unhelpmute_time)
 
         await crud.add_timed_restriction(member.id, unhelpmute_time, 'timehelpmute')
         await crud.add_permanent_role(member.id, self.bot.roles['help-mute'].id)
@@ -1003,7 +1004,7 @@ class Mod(commands.Cog):
 
         delta = datetime.timedelta(seconds=seconds)
         expiring_time = timestamp + delta
-        expiring_time_string = utils.dtm_to_discord_timestamp(expiring_time)
+        expiring_time_string = format_dt(expiring_time)
 
         await crud.add_timed_role(member.id, self.bot.roles['streamer(temp)'].id, expiring_time)
         msg_user = f"You have been given streaming permissions until {expiring_time_string}!"
@@ -1047,7 +1048,7 @@ class Mod(commands.Cog):
         timestamp = datetime.datetime.now()
 
         end_time = timestamp + delta
-        end_time_str = utils.dtm_to_discord_timestamp(end_time)
+        end_time_str = format_dt(end_time)
 
         await crud.add_timed_role(member.id, role.id, end_time)
         await member.add_roles(role, reason=reason)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,12 +3,12 @@ import discord
 import io
 import random
 import re
-import time
 import traceback
 
 from discord.ext import commands
+from discord.utils import format_dt
 from utils import crud
-from typing import Optional, Union, Literal
+from typing import Optional, Union
 
 
 class ConsoleColor(discord.Color):
@@ -142,12 +142,6 @@ def paginate_message(msg: str, prefix: str = '```', suffix: str = '```', max_siz
     return paginator
 
 
-def dtm_to_discord_timestamp(dtm_obj: datetime.datetime, date_format: Literal['d', 'D', 't', 'T', 'f', 'F', 'R'] = 'f', utc_time: bool = False) -> str:
-    if utc_time:
-        dtm_obj = dtm_obj.replace(tzinfo=datetime.timezone.utc).astimezone()
-    return f"<t:{int(time.mktime(dtm_obj.timetuple()))}:{date_format}>"
-
-
 def text_to_discord_file(text: str, *, name: str = 'output.txt'):
     encoded = text.encode("utf-8")
     return discord.File(filename=name, fp=io.BytesIO(encoded))
@@ -231,7 +225,7 @@ class VoteButtonEnd(discord.ui.Button['SimpleVoteView']):
             await self.view.calculate_votes()
             results = "results:\n" + '\n'.join(f"{op}: {count}" for op, count in self.view.count.items())
             await interaction.response.send_message(
-                f"Vote started {dtm_to_discord_timestamp(self.view.start, utc_time=True, date_format='R')} has finished.\n{results}")
+                f"Vote started {format_dt(self.view.start, style='R')} has finished.\n{results}")
             self.view.stop()
             await crud.remove_vote_view(self.view.custom_id)
         else:


### PR DESCRIPTION
This function is built into disnake as per the docs:
https://docs.disnake.dev/en/latest/api.html#disnake.utils.format_dt

This function is also exactly the same as discord.py's format_dt in
the event we switch back, however as discord.utils instead of disnake.utils:
https://discordpy.readthedocs.io/en/latest/api.html#discord.utils.format_dt
