### PR TITLE
moving transfersave guide to embed

### DIFF
--- a/cogs/assistance-cmds/transfersave.3ds.md
+++ b/cogs/assistance-cmds/transfersave.3ds.md
@@ -1,0 +1,20 @@
+---
+title: Cart to digital save transfer 
+help-desc: Cart to digital version save transfer tutorial
+aliases: ctdtransfer, ctdsave
+color: 9B59B6
+---
+
+# What you need:
+- A 3DS modded with Luma3DS CFW
+- Checkpoint
+- A 3DS Cartridge with a save in it
+- A digital version of the 3DS cartridge
+
+
+# Instructions:
+1. Power on your 3DS and open Checkpoint
+2. Wait for your apps to load before selecting the save you want to transfer. If it doesn't appear, hold B to refresh and make sure you have a save file in the game
+3. Press L to backup the cart's save file, give the save any name you want
+4. On the digital copy, press the save's name and then press the R button to restore it
+5. You're done!

--- a/cogs/assistance-cmds/tutorial/transfersave.3ds.md
+++ b/cogs/assistance-cmds/tutorial/transfersave.3ds.md
@@ -1,9 +1,0 @@
----
-title: Cart to digital version save transfer tutorial
-url: https://redkerry135.github.io/transfersave/
-help-desc: Links to cart to digital version save transfer tutorial
-aliases: carttodigitalsave,ctdsave
-color: 9B59B6
----
-
-A tutorial about how to transfer a save from the cart version of a game to a digital version of that game.


### PR DESCRIPTION
since it's a short guide, it would make more sense for the guide to be in an embed rather than on a seperate page