### PR TITLE
rules: directly send nickname_policy instead of having a duplicate text in source

### DIFF
--- a/cogs/rules.py
+++ b/cogs/rules.py
@@ -181,14 +181,7 @@ https://discord.gg/C29hYvh"""
     @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
     async def nick(self, ctx: KurisuContext):
         """Displays the Nickname and Avatar Policy."""
-        await ctx.send(f"🏷 ___Username/Nickname and Avatar policy___\n"
-                       f"Usernames are to be kept primarily alphanumeric, to keep them easy to tag and read. "
-                       f"Excessively long usernames are not acceptable. Usernames and avatars "
-                       f"that are annoying, offensive, inappropriate (\"nsfw\"), and/or disruptive to others are also not allowed.\n"
-                       f"Usernames that go against these rules will be assigned a nickname. "
-                       f"Users can request a specific nickname that follows these rules "
-                       f"by asking in {self.bot.channels['meta'].mention} or by sending a direct message to <@333857992170536961>.\n"
-                       f"Users with avatars against these rules will be asked to change them or be kicked from the server.")
+        await ctx.send(self.nickname_policy)
 
     @commands.command()
     async def rules(self, ctx: KurisuContext):


### PR DESCRIPTION
The str is literally already there, so just reuse that.