### PR TITLE
assistance: add an mkey generator command

### DIFF
--- a/cogs/assistance-cmds/mkey.3ds.md
+++ b/cogs/assistance-cmds/mkey.3ds.md
@@ -1,5 +1,0 @@
----
-help-desc: Master Key(mkey) generator for parental controls
----
-
-[Master key generator](https://mkey.salthax.org/) to remove the parental controls pin on Nintendo Consoles

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -259,12 +259,11 @@ class Assistance(commands.Cog):
         view.message = await ctx.send(embed=view.paginator.current(), view=view)
 
     @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
-    @commands.command(aliases=['generatemkey'])
-    async def mkey(self, ctx: KurisuContext, device: str, month: int, day: int, inquiry: str, deviceID: Optional[str]):
+    @commands.hybrid_command()
+    async def mkey(self, ctx: KurisuContext, device: str, month: int, day: int, inquiry: str, deviceid: Optional[str] = None):
         """
         Generate an mkey for given device.
-        Switch users will be directed to SALT's mkey website.
-        Usage: `mkey <3ds|dsi|wii|wiiu|switch> <month> <day> <inquiry (no space)> <deviceID (switch 8.0+ only)>`
+        Usage: `mkey <3ds|dsi|wii|wiiu|switch> <month> <day> <inquiry (no space)> <deviceid (switch 8.0+ only)>`
         """
         devices = {
             "3ds": "CTR",
@@ -275,17 +274,19 @@ class Assistance(commands.Cog):
             "nx": "HAC",
             "switch": "HAC"
         }
+        if deviceid and not ctx.interaction:
+            await ctx.message.delete()
         if device.lower() not in devices:
-            return await ctx.send(f'This device is not supported. Valid options are: {", ".join(i for i in devices)}')
+            return await ctx.send(f'{ctx.author.mention if not ctx.interaction else ""} This device is not supported. Valid options are: {", ".join(i for i in devices)}')
         apicall = f"https://mkey.eiphax.tech/{devices[device.lower()]}/{inquiry}/{month}/{day}"
-        if deviceID:
-            apicall += f"?aux={deviceID}"
+        if deviceid:
+            apicall += f"?aux={deviceid}"
         async with self.bot.session.get(apicall) as r:
             if r.status == 200:
                 ret = await r.json()
-                return await ctx.send(f'Your key is {ret["key"]}.')
+                return await ctx.send(f'{ctx.author.mention if not ctx.interaction else ""} Your key is {ret["key"]}.')
             else:
-                return await ctx.send(f"API returned error {r.status}. Please check your values and try again.")
+                return await ctx.send(f'{ctx.author.mention if not ctx.interaction else ""} API returned error {r.status}. Please check your values and try again.')
 
 
 add_md_files_as_commands(Assistance)

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -258,6 +258,35 @@ class Assistance(commands.Cog):
         view = PaginatedEmbedView(paginator=UniDBResultsPaginator(res), author=ctx.author)
         view.message = await ctx.send(embed=view.paginator.current(), view=view)
 
+    @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
+    @commands.command(aliases=['generatemkey'])
+    async def mkey(self, ctx: KurisuContext, device: str, month: int, day: int, inquiry: str, deviceID: Optional[str]):
+        """
+        Generate an mkey for given device.
+        Switch users will be directed to SALT's mkey website.
+        Usage: `mkey <3ds|dsi|wii|wiiu|switch> <month> <day> <inquiry (no space)> <deviceID (switch 8.0+ only)>`
+        """
+        devices = {
+            "3ds": "CTR",
+            "dsi": "TWL",
+            "wii": "RVL",
+            "wiiu": "WUP",
+            "ns": "HAC",
+            "nx": "HAC",
+            "switch": "HAC"
+        }
+        if device.lower() not in devices:
+            return await ctx.send(f'This device is not supported. Valid options are: {", ".join(i for i in devices)}')
+        apicall = f"https://mkey.eiphax.tech/{devices[device.lower()]}/{inquiry}/{month}/{day}"
+        if deviceID:
+            apicall += f"?aux={deviceID}"
+        async with self.bot.session.get(apicall) as r:
+            if r.status == 200:
+                ret = await r.json()
+                return await ctx.send(f'Your key is {ret["key"]}.')
+            else:
+                return await ctx.send(f"API returned error {r.status}. Please check your values and try again.")
+
 
 add_md_files_as_commands(Assistance)
 add_md_files_as_commands(Assistance, join(Assistance.data_dir, 'tutorial'), namespace=Assistance.tutorial)  # type: ignore

--- a/cogs/assistance.py
+++ b/cogs/assistance.py
@@ -4,7 +4,6 @@ import discord
 import logging
 
 from discord import app_commands
-from discord.app_commands import Choice
 from discord.ext import commands
 from inspect import cleandoc
 from os.path import dirname, join
@@ -267,26 +266,28 @@ class Assistance(commands.Cog):
                            day='The console\'s day.',
                            inquiry='Your inquiry number.',
                            device_id='Your device id. Only required on switch 8.0+.')
-    @app_commands.choices(
-        device=[
-            Choice(name="3ds", value="CTR"),
-            Choice(name="dsi", value="TWL"),
-            Choice(name="wii", value="RVL"),
-            Choice(name="wiiu", value="WUP"),
-            Choice(name="switch", value="HAC")
-        ],
-    )
-    async def mkey(self, ctx: KurisuContext, device: Choice[str], month: app_commands.Range[int, 1, 12], day: app_commands.Range[int, 1, 31], inquiry: str, device_id: Optional[str] = None):
+    async def mkey(self, ctx: KurisuContext, device: Literal['3ds', 'dsi', 'wii', 'wiiu', 'switch'], month: commands.Range[int, 1, 12], day: commands.Range[int, 1, 31], inquiry: str, device_id: Optional[str] = None):
         """
         Generate an master key for resetting parental control for given device.
         Usage: `mkey <3ds|dsi|wii|wiiu|switch> <month> <day> <inquiry (no space)> <deviceid (switch 8.0+ only)>`
         """
+
+        device_codes = {
+            "3ds": "CTR",
+            "dsi": "TWL",
+            "wii": "RVL",
+            "wiiu": "WUP",
+            "switch": "HAC"
+        }
+
+        device_code = device_codes[device]
+
         if device_id and not ctx.interaction:
             try:
                 await ctx.message.delete()
             except discord.Forbidden:
                 pass
-        api_call = f"https://mkey.eiphax.tech/{device.value}/{inquiry}/{month}/{day}"
+        api_call = f"https://mkey.eiphax.tech/{device_code}/{inquiry}/{month}/{day}"
         if device_id:
             api_call += f"?aux={device_id}"
         async with self.bot.session.get(api_call) as r:


### PR DESCRIPTION
Doesn't support Switch at this time, due to not having the prerequisite files on my API server. Also doesn't work with 3DS 7.0-7.1.

But it does make life simpler.

Also not really sure which cog to throw this in.