### PR TITLE
loop: fix null 'end' key in netinfo JSON

### DIFF
--- a/cogs/loop.py
+++ b/cogs/loop.py
@@ -75,7 +75,7 @@ class Loop(commands.Cog):
                 else:
                     begin = datetime(year=2000, month=1, day=1, tzinfo=self.bot.tz)
 
-                if "end" in entry:
+                if "end" in entry and entry["end"] is not None:
                     end = self.netinfo_parse_time(entry["end"])
                     entry_desc += '\nEnds: ' + format_dt(end)
                 else:


### PR DESCRIPTION
Turns out, with unintended maintenances, Nintendo uses `'end': null` as the key, instead of omitting the key entirely.

Account for this by checking if said key is not None.

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
