### PR TITLE
Remove appeals channel mention for appeal mute

### DIFF
--- a/utils/restrictions.py
+++ b/utils/restrictions.py
@@ -114,8 +114,9 @@ class RestrictionsManager(BaseManager, db_manager=RestrictionsDatabaseManager):
                     msg_user = messages[restriction]
                     if reason:
                         msg_user += " The given reason is: " + reason
-                    msg_user += ("\n\nIf you feel this was unjustified, "
-                                 f"you may appeal in {self.bot.channels['appeals'].mention}")
+                    if restriction != Restriction.AppealsMute:
+                        msg_user += ("\n\nIf you feel this was unjustified, "
+                                     f"you may appeal in {self.bot.channels['appeals'].mention}")
                     if end_date:
                         msg_user += f"\n\nThis restriction lasts until {format_dt(end_date)}."
                     await send_dm_message(user, msg_user)


### PR DESCRIPTION
<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->

Currently, if you receive the appeal mute role, it'll tell you to fix that in the channel you were just muted from. I am thinking this solution is the most ideal, but let me know if you guys want to pull somewhere else instead.