### PR TITLE
workflow: control flake8 from .flake8 config file 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = E501,E722,W503

--- a/.github/workflows/flake8_check.yml
+++ b/.github/workflows/flake8_check.yml
@@ -21,4 +21,4 @@ jobs:
         python -m pip install flake8
     - name: Check with flake8
       run: |
-        flake8 . --ignore=E501,E722,W503 --exclude=migrations
+        flake8 .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install flake8
       - name: Check with flake8
         run: |
-          flake8 . --ignore=E501,E722,E126,E128,W503,E121 --exclude=migrations
+          flake8 . --ignore=E501,E722,W503 --exclude=migrations
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install flake8
       - name: Check with flake8
         run: |
-          flake8 . --ignore=E501,E722,W503 --exclude=migrations
+          flake8 .
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
This way, when we add or remove warnings/errors, we can just edit one file, and also just run `flake8 .` locally instead of copypasting the entire command, warnings and all.