### PR TITLE
assistance: delete 3gxluma command

### DIFF
--- a/cogs/assistance-cmds/3gxluma.3ds.md
+++ b/cogs/assistance-cmds/3gxluma.3ds.md
@@ -1,9 +1,0 @@
----
-title: Luma3DS 3GX Loader edition
-url: https://github.com/PabloMK7/Luma3DS_3GX/releases
-author.name: LumaTeam & PabloMK7
-thumbnail-url: https://avatars.githubusercontent.com/u/10946643?v=4
-help-desc: Link to the BootNTR-specific Luma3DS build
----
-
-BootNTR fork of Luma3DS


### PR DESCRIPTION
It is now part of upstream Luma3DS

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
