### PR TITLE
Migrate more tags to commands

### DIFF
--- a/cogs/assistance-cmds/android.switch.md
+++ b/cogs/assistance-cmds/android.switch.md
@@ -1,0 +1,9 @@
+---
+title: Android 10 Setup Guide
+url: https://wiki.switchroot.org/en/Android/Setup-10.html
+thumbnail-url: https://gitlab.com/uploads/-/system/group/avatar/4623003/switchroot.png
+author.name: Switchroot
+help-desc: Guide to set up Android on a Nintendo Switch
+---
+
+Setup Android on a Nintendo Switch

--- a/cogs/assistance-cmds/b9sntr.3ds.md
+++ b/cogs/assistance-cmds/b9sntr.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Installing boot9strap (ntrboot)
+url: https://3ds.hacks.guide/installing-boot9strap-(ntrboot).html
+help-desc: Links to ntrboot guide with flashcart already flashed with ntrboot
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhplai.png
+author.name: NH & Friends
+---
+
+CFW installation guide using ntrboot

--- a/cogs/assistance-cmds/bfm4.3ds.md
+++ b/cogs/assistance-cmds/bfm4.3ds.md
@@ -1,0 +1,9 @@
+---
+title: BruteforceMovable Advice
+help-desc: What to do whem BFM skips to step 4
+---
+
+If BruteforceMovable is now at step 4, download your `movable.sed` and continue. You do not need to do anything more related to `movable_part1.sed`, Python, or the command line. The `movable.sed` is the final product and requires no further processing.
+**You do not need to go back and get the friend code, or do anything more with the friend code.**
+**It does not matter if the friend does not add you back.**
+The bot already has your information and has removed you as a friend.

--- a/cogs/assistance-cmds/cfwcheck.3ds.md
+++ b/cogs/assistance-cmds/cfwcheck.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Checking for CFW
+url: https://3ds.hacks.guide/checking-for-cfw.html
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhplai.png
+author.name: NH & Friends
+help-desc: Links the 3DS CFW check guide
+---
+
+How to check if your console already has custom firmware installed

--- a/cogs/assistance-cmds/cfwuses.wiiu.md
+++ b/cogs/assistance-cmds/cfwuses.wiiu.md
@@ -4,7 +4,7 @@ help-desc: Uses for CFW on Wii U, Switch, and 3DS
 ---
 
 # Among other things, it allows you to do the following:
-- Use “ROM hacks” for games that you own.
+- Use "ROM hacks" for games that you own.
 - Backup, edit and restore saves for many games.
 - Play games for older systems with various emulators, using RetroArch or other standalone emulators.
 - Play out-of-region games.

--- a/cogs/assistance-cmds/ctr.3ds.md
+++ b/cogs/assistance-cmds/ctr.3ds.md
@@ -1,5 +1,5 @@
 ---
-title: Guide - ctrtransfer
+title: Guide - CTRTransfer
 url: https://3ds.hacks.guide/ctrtransfer.html
 thumbnail-url: https://nintendohomebrew.com/assets/img/nhplai.png
 author.name: NH & Friends
@@ -7,4 +7,4 @@ aliases: ctrtransfer,ctrnandtransfer
 help-desc: Links to ctrtransfer guide
 ---
 
-How to do the 11.15.0-47 ctrtransfer
+How to do the 11.15.0-47 CTRTransfer

--- a/cogs/assistance-cmds/dump.switch.md
+++ b/cogs/assistance-cmds/dump.switch.md
@@ -8,4 +8,4 @@ help-desc: How to dump games and data for CFW consoles
 ---
 
 How to dump/build NSPs using NXDumpTool
-BAN Warning: only for use with offline emummc
+BAN Warning: only for use with offline emuMMC

--- a/cogs/assistance-cmds/eshoperror.3ds.md
+++ b/cogs/assistance-cmds/eshoperror.3ds.md
@@ -1,0 +1,8 @@
+---
+title: Fix Error Code 005-8024 when using eShop
+help-desc: Troubleshooting error 005-8024 on 3DS eShop
+aliases: 005-8024
+---
+
+1. Navigate to the following folder on your SD card: `/Nintendo 3DS/(32 Character ID)/(32 Character ID)/extdata/00000000/`
+2. Delete these folders if you have them: `00000219`, `00000229`, `00000209`

--- a/cogs/assistance-cmds/exfat.switch.md
+++ b/cogs/assistance-cmds/exfat.switch.md
@@ -7,12 +7,12 @@ The recommended filesystem format for the Switch is FAT32.
 
 While the Switch supports exFAT through an additional update from Nintendo, here are reasons not to use it:
 
-* CFW may fail to boot due to a missing exFAT update in Horizon
-* This filesystem is prone to corruption.
-* Nintendo doesn't use files larger than 4GB, even with large games and exFAT.
+- CFW may fail to boot due to a missing exFAT update in Horizon
+- This filesystem is prone to corruption.
+- Nintendo doesn't use files larger than 4GB, even with large games and exFAT.
 
 Here are some links to common FAT32 formatting tools:
-• [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) (Windows)
-• [gparted](https://gparted.org/download.php) + [dosfstools](https://github.com/dosfstools/dosfstools) (Linux)
-• [Disk Utility](https://support.apple.com/guide/disk-utility/format-a-disk-for-windows-computers-dskutl1010) (MacOS)
+- [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) (Windows)
+- [gparted](https://gparted.org/download.php) + [dosfstools](https://github.com/dosfstools/dosfstools) (Linux)
+- [Disk Utility](https://support.apple.com/guide/disk-utility/format-a-disk-for-windows-computers-dskutl1010) (MacOS)
 MacOS: Always select "MS-DOS (FAT)", even if the card is larger than 32GB.

--- a/cogs/assistance-cmds/fixguiformat.all.md
+++ b/cogs/assistance-cmds/fixguiformat.all.md
@@ -1,0 +1,9 @@
+---
+title: Fix GUIFormat errors
+help-desc: Common troubleshooting for GUIFormat issues
+aliases: fixformat
+---
+
+If you struggle to format your SD card / USB device to FAT32 using GUIFormat, close any applications that might be accessing the SD card right now (such as File Explorer).
+
+If this doesn't help, move GUIFormat to your desktop, and restart your PC. After you are back on the desktop, before doing anything else, format the SD card with GUIFormat. Run GUIFormat from the desktop to do so (avoid opening the File Explorer).

--- a/cogs/assistance-cmds/fixnvram.3ds.md
+++ b/cogs/assistance-cmds/fixnvram.3ds.md
@@ -1,0 +1,11 @@
+---
+title: Fixing NVRAM issues
+help-desc: Tutorial on replacing the NVRAM on a 3DS family console with a clean replacement
+---
+
+1. Download: [NVRAM tool](https://github.com/zoogie/Stuff/raw/master/3DS_NVRAMtool/3DS_NVRAMtool.3dsx)
+2. Download: [a clean nvram.bin](https://i.n7.pm/nvram)
+3. Place both files in the 3ds folder on the root of your SD card.
+4. Open the homebrew launcher and then open the NVRAM tool from there.
+5. After the app opens, press B, then press X.
+6. Reboot and then try a DS game

--- a/cogs/assistance-cmds/hblc.wiiu.md
+++ b/cogs/assistance-cmds/hblc.wiiu.md
@@ -1,0 +1,12 @@
+---
+title: Entering Homebrew Launcher
+help-desc: What to and not to do to open the HBL
+---
+
+After installing Tiramisu, you can simply open the Mii Maker to enter the Homebrew Launcher.
+
+Using the standalone *Homebrew Launcher Channel* is not recommended and might cause crashes and freezes.
+If you still want to install the HBLC, download the following file and copy it to the `install` folder on the root of your SD Card: <https://github.com/GaryOderNichts/homebrew_launcher/releases/tag/v2.1_fix>
+After installing the Channel using WUP Installer GX2, remove the `sd:\wiiu\environments\tiramisu\modules\setup\50_hbl_installer.rpx` file from your SD Card.
+
+*Note:* This will also remove the HBL injection from the Mii Maker.

--- a/cogs/assistance-cmds/incognito.switch.md
+++ b/cogs/assistance-cmds/incognito.switch.md
@@ -1,0 +1,12 @@
+---
+title: Why not Incognito?
+help-desc: Describes why Incognito is bad and should not be used
+---
+
+Incognito isn't an effective method for ban prevention. 
+
+- The console still connects to Nintendo, but they choose to ignore it completely, due to invalid console security data. **Note that this could change at any time.**
+- It destructively erases unique data that cannot be regenerated in case its backup is lost. This means that you risk permanently self-banning your console inadvertently.
+- Traces of Incognito remain on the system even *after* it is disabled, which works against the point of Incognito safeguarding you in the first place.
+
+90DNS / dns.mitm are both more effective methods at ban prevention since they completely prevent the Switch from connecting to Nintendo. Instructions for their use can be found here: https://nh-server.github.io/switch-guide/extras/blocking_nintendo/

--- a/cogs/assistance-cmds/miimine.3ds.md
+++ b/cogs/assistance-cmds/miimine.3ds.md
@@ -1,0 +1,11 @@
+---
+title: Seedminer (Mii)
+url: https://3ds.hacks.guide/seedminer-(mii).html
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhplai.png
+author.name: NH & Friends
+author.url: https://3ds.hacks.guide/seedminer-(mii).html
+help-desc: Links the Mii Mining guide
+aliases: seedmiiner
+---
+
+A guide on how to do the Mii mining process to get your 3DS' `movable.sed` file

--- a/cogs/assistance-cmds/nxdrivers.switch.md
+++ b/cogs/assistance-cmds/nxdrivers.switch.md
@@ -1,0 +1,19 @@
+---
+title: Debugging TegraRCMGui
+help-desc: Common troubleshooting steps for injecting payloads into RCM
+---
+
+If you're having TegraRCMGui errors, driver issues or your Switch is just straight up being weird when trying to inject a payload via RCM, get [Zadig](https://zadig.akeo.ie/) and:
+1. Boot out of RCM and into stock (if already in RCM)
+2. Connect Switch to pc
+3. Let Windows install default drivers (if it hasn't already)
+4. Disconnect from PC, power off Switch and boot into rcm
+5. Load Zadig
+6. Connect Switch to pc
+7. In Zadig, find "APX" in device list
+8. For driver type, select libusbK (3.0.7.0)
+9. Install that driver
+10. Close zadig
+11. Open TegraRCMGui and inject the payload
+
+If this still doesn't work, cycle out of and back into RCM and try again.

--- a/cogs/assistance-cmds/regionunlock.wiiu.md
+++ b/cogs/assistance-cmds/regionunlock.wiiu.md
@@ -1,0 +1,17 @@
+---
+title: How to region unlock the Wii U:
+help-desc: Explain how to run out of region games on the Wii U.
+aliases: ourloader
+---
+
+### Tiramisu:
+1. Download [OurLoader](https://cdn.discordapp.com/attachments/279783073497874442/736000233418260580/ourloader.elf).
+2. Copy it to `sd:/wiiu/apps`.
+3. Load the Homebrew Launcher.
+4. Load OurLoader.
+5. Insert the disc into the console.
+6. Press A to launch the disk.
+7. The game should load.
+
+### Aroma
+Aroma is bundled with the RegionFree Plugin. You can configure it in the Plugin Menu.

--- a/cogs/assistance-cmds/rosalinabutton.3ds.md
+++ b/cogs/assistance-cmds/rosalinabutton.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Open Rosalina when the buttons are broken
+help-desc: Links to a custom Luma3DS config.ini that changes the button combo
+aliases: 3dsconfig
+---
+
+If one of your buttons required to open Rosalina menu is broken, then place this config.ini in your luma folder, replacing the existing one if there's already one there. Press X+Y to open Rosalina menu. You can change this button under the misc. options and save.
+
+<https://3ds.hacks.guide/assets/config.ini>

--- a/cogs/assistance-cmds/sdcafiine.wiiu.md
+++ b/cogs/assistance-cmds/sdcafiine.wiiu.md
@@ -1,0 +1,10 @@
+---
+title: SDCafiine
+url: https://wiki.hacks.guide/wiki/Wii_U:SDCafiine
+author.name: NH Discord Server
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to the guide on using SDCafiine
+color: 66FFFF
+---
+
+Wii U mod manager

--- a/cogs/assistance-cmds/sdclean.all.md
+++ b/cogs/assistance-cmds/sdclean.all.md
@@ -1,0 +1,11 @@
+---
+title: SD Clean
+url: https://wiki.hacks.guide/wiki/SD_Clean
+author.name: NH Discord Server
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to the guide on completely resetting an SD card
+aliases: sdunfuck
+color: 66FFFF
+---
+
+Completely erase and reset an SD card

--- a/cogs/assistance-cmds/sdexplain.all.md
+++ b/cogs/assistance-cmds/sdexplain.all.md
@@ -1,0 +1,18 @@
+---
+title: Kinds of SD cards
+help-desc: Explains what type of SD cards are out there
+---
+
+There are two different **physical** SD card standards and three different **electrical** SD card standards that you may see.
+
+SD cards, physically, are either (full-size) SD or microSD cards. SD and microSD cards are identical, and you can use a microSD card in **any** device that expects a full-sized SD card, with a simple adapter.
+
+Electrically, there are three common SD standards: SD, SDHC and SDXC.
+
+SD covers SD cards up to 2GB in size. Certain older devices can only use standard SD cards, which means that any SD card over 2GB will not work in them. In the world of Nintendo hacking, this only matters for the Wii - It received a firmware update to add support for higher-capacity cards, but not all games (ex. Super Smash Bros Brawl) support it.
+
+SDHC covers cards between 4GB and 32GB. This is officially the specification that the 3DS and Wii U follow. The SDHC specification requires that all SD cards are formatted to FAT32, so these devices can only read FAT32 formatted SD cards.
+
+The SDXC specification is for cards between 64GB and 2TB. It is **identical** to SDHC, with the exception that it requires that the SD card be formatted to exFAT. This means that most devices that expect an SDHC card (3DS, Wii U, etc) will work with an SDXC card, but you will need to manually format it in a computer beforehand.
+
+Windows will, by default, not let you format SD cards over 32GB to FAT32. This is due to purely historic reasons, but it does mean that an external program is required to format these cards. Type `.sdformat` in <#261581918653513729> to see a guide you can follow to format cards to FAT32.

--- a/cogs/assistance-cmds/sdguide.3ds.md
+++ b/cogs/assistance-cmds/sdguide.3ds.md
@@ -4,4 +4,4 @@ help-desc: SD Troubleshooter
 aliases: sderror,sderrors,sd
 ---
 
-Need to do something with your SD card? Find advice in [this guide](https://3ds.eiphax.tech/sd.html)
+Need to do something with your SD card? Find advice in [this guide](https://3ds.eiphax.tech/sd)

--- a/cogs/assistance-cmds/sdlayout.wiiu.md
+++ b/cogs/assistance-cmds/sdlayout.wiiu.md
@@ -1,0 +1,6 @@
+---
+title: Wii U SD layout
+help-desc: A quick overview of the Wii U SD card contents
+---
+
+The file structure of your SD card should look like this: https://wiiu.eiphax.tech/sdlayout

--- a/cogs/assistance-cmds/sdreco.3ds.md
+++ b/cogs/assistance-cmds/sdreco.3ds.md
@@ -1,0 +1,11 @@
+---
+title: SD Cards for the 3DS
+help-desc: Description of which SD cards should be used in a 3DS family console
+aliases: 3dssd
+---
+
+The 3DS *can* use SD cards up to 2TB in size. However, using cards larger than 128GB is not recommended, as it tends to cause issues. Any cards over 32GB will have to be formatted to FAT32 in a computer or hacked console before they can be used (use an allocation unit size of 32KB/32768 for 64GB cards and 64KB/65536 for 128GB cards or larger).
+
+Buy SD cards from reputable brands (SanDisk, Samsung, Kingston, etc.). Preferably, purchase cards from a brick and mortar store near you, but Amazon is okay if you must purchase online. __**NEVER**__ buy cards from AliExpress, Wish, eBay or other similar sites.
+
+Speed is irrelevant for the 3DS - it is limited to Class 4 (4MB/s) speeds. The only reason to buy a faster SD card is for faster data transfer to your computer.

--- a/cogs/assistance-cmds/seedminer.3ds.md
+++ b/cogs/assistance-cmds/seedminer.3ds.md
@@ -7,4 +7,4 @@ author.url: https://3ds.hacks.guide/seedminer
 help-desc: Links the seedminer guide
 ---
 
-A guide on how to do the seedminer process to get your 3ds' movable.sed file
+A guide on how to do the Seedminer process to get your 3DS' `movable.sed` file

--- a/cogs/assistance-cmds/skater.3ds.md
+++ b/cogs/assistance-cmds/skater.3ds.md
@@ -1,0 +1,11 @@
+---
+title: super-skaterhax Troubleshooting
+help-desc: Common troubleshooting steps for super-skaterhax exploit
+image-url: https://cdn.discordapp.com/attachments/717477397200634011/1114323135827824700/skater_lang.png
+---
+
+- Is your console set to the current date?
+- Do you have the files you need (`arm11code.bin`,  `browserhax_hblauncher_ropbin_payload.bin`, `boot.3dsx`) on the root of the SD card (NOT the `Nintendo 3DS` folder)?
+- Have you reset your browser settings? (browser menu -> Settings -> Reset Save Data)
+- Did you select the correct payload for your region AND system version?
+- Are your region settings set according to the following image?

--- a/cogs/assistance-cmds/syscheck.wii.md
+++ b/cogs/assistance-cmds/syscheck.wii.md
@@ -1,0 +1,10 @@
+---
+title: SysCheck
+url: https://wii.guide/syscheck.html
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/wii.png
+author.name: RiiConnect24
+author.url: https://wii.guide/syscheck.html
+help-desc: Wii System checking tool for debugging console issues
+---
+
+Wii System Check tool

--- a/cogs/assistance-cmds/tegraexplorer.switch.md
+++ b/cogs/assistance-cmds/tegraexplorer.switch.md
@@ -1,0 +1,12 @@
+---
+title: TegraExplorer
+url: https://github.com/suchmememanyskill/TegraExplorer/releases
+thumbnail-url: https://avatars.githubusercontent.com/u/38142618
+author.name: Such Meme, Many Skill
+author.url: https://github.com/suchmememanyskill
+help-desc: Download link for the latest TegraExplorer version
+aliases: te
+color: 3498db
+---
+
+Payload-based file manager

--- a/cogs/assistance-cmds/titlekeys.wiiu.md
+++ b/cogs/assistance-cmds/titlekeys.wiiu.md
@@ -1,0 +1,6 @@
+---
+title: Dumping title keys
+help-desc: Guide to dump title keys from a Wii U
+---
+
+A guide for dumping title keys can be found here: https://wiiu.eiphax.tech/keydump

--- a/cogs/assistance-cmds/torrent.all.md
+++ b/cogs/assistance-cmds/torrent.all.md
@@ -5,6 +5,6 @@ aliases: torrentclients,torrentclient
 ---
 
 Here are links to some good torrent clients:
-• [qBittorrent](https://www.qbittorrent.org/download.php)
-• [Deluge](https://dev.deluge-torrent.org/wiki/Download)
-• [Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud&hl=en_US) (Android)
+- [qBittorrent](https://www.qbittorrent.org/download.php)
+- [Deluge](https://dev.deluge-torrent.org/wiki/Download)
+- [Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud&hl=en_US) (Android)

--- a/cogs/assistance-cmds/trimgame.3ds.md
+++ b/cogs/assistance-cmds/trimgame.3ds.md
@@ -1,0 +1,12 @@
+---
+title: What are trimmed cartridge dumps?
+help-desc: Explain how ROM trimming works
+---
+
+All cartridges use memory chips which are in powers of 2 (as in 4, 8, 16, 32, 64, 128). If a game is 120MiB, it will be stored on a 128MiB chip and include 8MiB of 'padding' (garbage data) so the operating system does not think there is more content beyond the actual game and get confused.
+
+Dumping the 'trimmed' game removes this padding data. However, some utilities (like patchers) use this 'padding' data to insert their own patch data, which means if you do not include the padding data, the patchers will be unable to insert their data.
+
+If you intend to use the game for ROM hacks or `.xdelta` patches or something like that, get the untrimmed version.
+
+If you just intend to use the game as its own game, get the trimmed version.

--- a/cogs/assistance-cmds/trimgame.dsi.md
+++ b/cogs/assistance-cmds/trimgame.dsi.md
@@ -1,0 +1,12 @@
+---
+title: What are trimmed cartridge dumps?
+help-desc: Explain how ROM trimming works
+---
+
+All cartridges use memory chips which are in powers of 2 (as in 4, 8, 16, 32, 64, 128). If a game is 120MiB, it will be stored on a 128MiB chip and include 8MiB of 'padding' (garbage data) so the operating system does not think there is more content beyond the actual game and get confused.
+
+Dumping the 'trimmed' game removes this padding data. However, some utilities (like patchers) use this 'padding' data to insert their own patch data, which means if you do not include the padding data, the patchers will be unable to insert their data.
+
+If you intend to use the game for ROM hacks or `.xdelta` patches or something like that, get the untrimmed version.
+
+If you just intend to use the game as its own game, get the trimmed version.


### PR DESCRIPTION
None of this was tested, because for whatever reason Kurisu refuses to run on my Windows PC. But also it's markdown so it probably won't die.

Summary:
- The following are moved from tags to commands:
  - switchandroid -> android 
  - b9sntr
  - bfm4 (partial revert of previous removal as a command)
  - cfwcheck
  - 005-8024 -> eshoperror (original name aliased)
  - fixformat -> fixguiformat (original name aliased)
  - fixnvram
  - wiiu-hblc -> hblc
  - incognito
  - seedmiiner -> miimine (original name aliased)
  - nxdrivers
  - 3dsconfig -> rosalinabuttons (original name aliased)
  - sdcafiine
  - sdunfuck -> sdclean (original name aliased)
  - sdexplain
  - wiiusdlayout -> sdlayout
  - 3dssd -> sdreco (original name aliased)
  - skater
  - syscheck
  - tegraexplorer/te -> tegraexplorer (te aliased)
  - wiiutitlekeys -> titlekeys
  - trimgame
  - ourloader -> regionunlock (original name aliased)
- Trivial changes to existing markdown to try and standardize
