### PR TITLE
Fix android 11 link

### DIFF
--- a/cogs/assistance-cmds/android.switch.md
+++ b/cogs/assistance-cmds/android.switch.md
@@ -1,6 +1,6 @@
 ---
 title: Android 11 Setup Guide
-url: https://wiki.switchroot.org/Android/Setup-11.html
+url: https://wiki.switchroot.org/wiki/android/11-r-setup-guide
 thumbnail-url: https://gitlab.com/uploads/-/system/group/avatar/4623003/switchroot.png
 author.name: Switchroot
 help-desc: Guide to set up Android on a Nintendo Switch


### PR DESCRIPTION
The original link no longer exists, this changes that.