### PR TITLE
lumabug -> rtcbug

### DIFF
--- a/cogs/assistance-cmds/rtcbug.3ds.md
+++ b/cogs/assistance-cmds/rtcbug.3ds.md
@@ -1,6 +1,7 @@
 ---
-title: Luma Black Screen Bug
-help-desc: Luma Black Screen Bug
+title: RTC black screen bug
+help-desc: RTC black screen bug
+aliases: lumabug
 ---
 
 If you have Luma3DS and your console is stuck on a black screen after you power it on, follow these steps:


### PR DESCRIPTION
Discussed on https://wiki.hacks.guide/wiki/3DS_talk:RTC_black_screen_bug#Page_rename the page was renamed from "lumabug" to stop associating the issue with Luma3DS, since the actual bug lies with something else entirely.

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
