### PR TITLE
Fix sending payload link in ssnc

### DIFF
--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -140,7 +140,7 @@ class SwitchSerialNumberCheck(Cog):
         elif maybe:
             return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
                                   "pushing the payload manually. You can find instructions to do so here: "
-                                  "https://switch.hacks.guide/user_guide/emummc/sending_payload/".format(ctx.author.mention,
+                                  "https://switch.hacks.guide/user_guide/rcm/sending_payload/".format(ctx.author.mention,
                                                                                                          safe_serial), ephemeral=True)
         elif patched:
             return await ctx.send("{}: Serial {} is patched.".format(ctx.author.mention, safe_serial), ephemeral=True)

--- a/cogs/ssnc.py
+++ b/cogs/ssnc.py
@@ -141,7 +141,7 @@ class SwitchSerialNumberCheck(Cog):
             return await ctx.send("{}: Serial {} _might_ be patched. The only way you can know this for sure is by "
                                   "pushing the payload manually. You can find instructions to do so here: "
                                   "https://switch.hacks.guide/user_guide/rcm/sending_payload/".format(ctx.author.mention,
-                                                                                                         safe_serial), ephemeral=True)
+                                                                                                      safe_serial), ephemeral=True)
         elif patched:
             return await ctx.send("{}: Serial {} is patched.".format(ctx.author.mention, safe_serial), ephemeral=True)
         else:


### PR DESCRIPTION
Replace the incorrect link in the .ssnc command with the correct one.