### PR TITLE
Update faketik command to match transfer command

### DIFF
--- a/cogs/assistance-cmds/faketik.3ds.md
+++ b/cogs/assistance-cmds/faketik.3ds.md
@@ -1,6 +1,10 @@
 ---
-help-desc: Download link for faketik
+Title: Restore apps wih missing tickets
+help-desc: How to download and run faketik
 aliases: faketiks
 ---
 
-3DS ticket spoofing utility, faketik: [faketik.3dsx](https://github.com/ihaveamac/faketik/releases)
+1. Download [faketik](https://github.com/ihaveamac/faketik/releases) and place `faketik.3dsx` in the `/3ds` folder on your SD root.
+2. To access the Homebrew Launcher, follow "Manually entering Homebrew Launcher" under "Other troubleshooting" on the [troubleshooting page](https://3ds.hacks.guide/troubleshooting#other-troubleshooting)
+3. Once you are in the Homebrew Launcher, run faketik.
+4. Your apps should appear on the home screen!


### PR DESCRIPTION
Add the new extended directions from system transfer to the faketik command to help the users and avoid extra typing
