### PR TITLE
assistancewii: Add `wiierror`

### DIFF
--- a/cogs/assistancewii.py
+++ b/cogs/assistancewii.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 import logging
 from os.path import dirname, join
+from typing import TYPE_CHECKING
 
+import discord
 from discord.ext import commands
+from markdownify import markdownify
 
 from utils.mdcmd import add_md_files_as_commands
+from utils.utils import ConsoleColor, KurisuCooldown
+
+if TYPE_CHECKING:
+    from kurisu import Kurisu
+    from utils.context import KurisuContext
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +23,34 @@ class AssistanceWii(commands.GroupCog):
     Wii help commands that will mostly be used in the help channels.
     """
     data_dir = join(dirname(__file__), 'assistance-cmds')
+
+    def __init__(self, bot: Kurisu):
+        self.bot: Kurisu = bot
+
+    @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
+    @commands.command(aliases=["wfcerror"])
+    async def wiierror(self, ctx: KurisuContext, error: int):
+        """
+        Get information about an error code displayed on the Wii and/or the Nintendo WFC.
+        Usage: `wiierror <error code>`
+        """
+        # It seems error codes must be within 6 digits
+        if error > 999999:
+            return await ctx.send(f"{ctx.author.mention} This is an invalid error code. Please try again.")
+        apicall = f"https://wiimmfi.de/error?m=json&e={error}"
+        async with ctx.typing():
+            async with self.bot.session.get(apicall) as r:
+                if r.status == 200:
+                    response = await r.json()
+                    if response[0]["found"] == 0:
+                        return await ctx.send(f"{ctx.author.mention} This error code does not exist.")
+                    else:
+                        embed = discord.Embed(title=f"Error {error}", colour=ConsoleColor.wii())
+                        for i in response[0]["infolist"]:
+                            embed.add_field(name=i["type"], value=f'**{i["name"]}**: {markdownify(i["info"])}', inline=False)
+                        return await ctx.send(embed=embed)
+                else:
+                    return await ctx.send(f'{ctx.author.mention} API returned error {r.status}. Please check your values and try again.')
 
 
 add_md_files_as_commands(AssistanceWii, console_cmd="wii")

--- a/cogs/assistancewii.py
+++ b/cogs/assistancewii.py
@@ -27,6 +27,9 @@ class AssistanceWii(commands.GroupCog):
     def __init__(self, bot: Kurisu):
         self.bot: Kurisu = bot
 
+    # Cached error codes from Wiimmfi
+    saved_errors = []
+
     @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
     @commands.command(aliases=["wfcerror"])
     async def wiierror(self, ctx: KurisuContext, error: int):
@@ -38,19 +41,33 @@ class AssistanceWii(commands.GroupCog):
         if error > 999999:
             return await ctx.send(f"{ctx.author.mention} This is an invalid error code. Please try again.")
         apicall = f"https://wiimmfi.de/error?m=json&e={error}"
-        async with ctx.typing():
-            async with self.bot.session.get(apicall) as r:
-                if r.status == 200:
-                    response = await r.json()
-                    if response[0]["found"] == 0:
-                        return await ctx.send(f"{ctx.author.mention} This error code does not exist.")
+
+        errorinfo = {}
+
+        # Check if we have this error cached
+        for i in self.saved_errors:
+            if i["error"] == error:
+                errorinfo = i
+
+        # If our error wasn't cached, go ask Wiimmfi
+        if not errorinfo:
+            async with ctx.typing():
+                async with self.bot.session.get(apicall) as r:
+                    if r.status == 200:
+                        response = await r.json()
+                        errorinfo = response[0]
+                        # Cache the error
+                        self.saved_errors.append(response[0])
                     else:
-                        embed = discord.Embed(title=f"Error {error}", colour=ConsoleColor.wii())
-                        for i in response[0]["infolist"]:
-                            embed.add_field(name=i["type"], value=f'**{i["name"]}**: {markdownify(i["info"])}', inline=False)
-                        return await ctx.send(embed=embed)
-                else:
-                    return await ctx.send(f'{ctx.author.mention} API returned error {r.status}. Please check your values and try again.')
+                        return await ctx.send(f'{ctx.author.mention} API returned error {r.status}. Please check your values and try again.')
+
+        if errorinfo["found"] == 0:
+            return await ctx.send(f"{ctx.author.mention} This error code does not exist.")
+        else:
+            embed = discord.Embed(title=f"Error {error}", colour=ConsoleColor.wii())
+            for i in errorinfo["infolist"]:
+                embed.add_field(name=i["type"], value=f'**{i["name"]}**: {markdownify(i["info"])}', inline=False)
+            return await ctx.send(embed=embed)
 
 
 add_md_files_as_commands(AssistanceWii, console_cmd="wii")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytz==2024.1
 asyncpg==0.29.0
 python-Levenshtein==0.25.1
 pillow-heif==0.17.0
+markdownify==0.13.1


### PR DESCRIPTION
This leverages Wiimmfi's extensive error code database API to provide users a simple way to describe error codes displayed on the Wii and/or the Nintendo WFC.

Add needed __init__ function for the AssistanceWii class to access the Kurisu bot object.

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
