### PR TITLE
Rework Warn System

### DIFF
--- a/cogs/filters.py
+++ b/cogs/filters.py
@@ -134,7 +134,7 @@ class Filter(commands.Cog):
         invalid = []
 
         for word in word_list.copy():
-            if type == 'join' and discord.utils.get(self.filters.filtered_words, word=word):  # type: ignore
+            if type == 'join' and discord.utils.get(self.filters.filtered_words, word=word):
                 word_list.remove(word)
                 repeat.append(word)
             elif ' ' in word or '-' in word:

--- a/schema.sql
+++ b/schema.sql
@@ -143,6 +143,8 @@ create table warns
 	user_id BIGINT NOT NULL REFERENCES members(id),
 	issuer_id BIGINT NOT NULL REFERENCES members(id),
 	reason TEXT,
+    type INT NOT NULL,
+    state INT NOT NULL,
 	deletion_time timestamptz,
 	deletion_reason TEXT,
     deleter BIGINT REFERENCES members(id)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,8 +8,8 @@ from .restrictions import RestrictionsManager, Restriction
 from .utils import ordinal, send_dm_message
 from .checks import check_staff, is_staff, is_staff_app
 from .userlog import UserLogManager
-from .warns import WarnsManager
+from .warns import WarnsManager, WarnState, WarnType
 
 __all__ = ['ConfigurationManager', 'StaffRank', 'MemberOrID', 'OptionalMember', 'ExtrasManager', 'BaseManager',
            'FiltersManager', 'RestrictionsManager', 'Restriction', 'ordinal', 'send_dm_message', 'check_staff', 'is_staff',
-           'is_staff_app', 'UserLogManager', 'WarnsManager']
+           'is_staff_app', 'UserLogManager', 'WarnsManager', 'WarnState', 'WarnType']


### PR DESCRIPTION
- Now there is 2 types of warns, `ephemeral` and `pinned`
  - `ephemeral` warns are the default type of warn and expire after 180 days
  -  `pinned` warns are applied with the `.pinwarn` command (works the same as `.warn`), `pinned` warns do not expire and are only deleted by staff.
  -  Expired or deleted warns are still kept in the DB and can be seen with the `modsense` slash command.
- **All** old warns will be converted to `ephemeral` warns meaning a lot of warns will be deleted once its implemented.
  - It's straight up impossible to check warns one by one to see which one should be a `pinned` warn, currently the DB has 6143 warns logged
- Added new slash command, `multiwarn` which can apply multiple warns at once, works the same as softwarn but you can also select if you want all the warns to be `ephemeral` or `pinned` (meaning you dont need to spam softwarn or pinwarn)