### PR TITLE
hotkey.wiiu and payloadfail.wiiu Commands

### DIFF
--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -1,0 +1,12 @@
+---
+title: Wii U Homebrew Environment Hotkeys
+help-desc: Various important button combinations to access different menus or perform certain actions in the Wii U Homebrew environment.
+aliases: uhotkeys,uhotkey,wiiuhotkeys,wiiucombo
+---
+Press the following keys in their given circumstances to access menus or perform actions.
+
+Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT on the Wii U Menu
+Skip modifications: Hold <:3ds_button_r:295004508294086656> on bootup
+Environment Loader: Hold <:3ds_button_x:295004476056535041> on bootup
+Payload Loader: Hold <:3ds_button_b:295004466963283968> on bootup
+Aroma Boot Selector: Hold START on bootup

--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -8,5 +8,6 @@ Press the following keys in their given circumstances to access menus or perform
 Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT on the Wii U Menu
 Skip modifications: Hold <:3ds_button_r:295004508294086656> on bootup
 Environment Loader: Hold <:3ds_button_x:295004476056535041> on bootup
-Payload Loader: Hold <:3ds_button_b:295004466963283968> on bootup
+PayloadLoader: Hold the <:3ds_button_b:295004466963283968> button on boot up.
+
 Aroma Boot Selector: Hold the START button on boot up.

--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -9,4 +9,4 @@ Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:29
 Skip modifications: Hold <:3ds_button_r:295004508294086656> on bootup
 Environment Loader: Hold <:3ds_button_x:295004476056535041> on bootup
 Payload Loader: Hold <:3ds_button_b:295004466963283968> on bootup
-Aroma Boot Selector: Hold START on bootup
+Aroma Boot Selector: Hold the START button on boot up.

--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -6,7 +6,8 @@ aliases: uhotkeys,uhotkey,wiiuhotkeys,wiiucombo
 Press the following keys in their given circumstances to access menus or perform actions.
 
 Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT on the Wii U Menu
-Skip modifications: Hold <:3ds_button_r:295004508294086656> on bootup
+Skip modifications: Hold the <:3ds_button_r:295004508294086656> button on boot up.
+
 EnvironmentLoader: Hold the <:3ds_button_x:295004476056535041> button on boot up.
 
 PayloadLoader: Hold the <:3ds_button_b:295004466963283968> button on boot up.

--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -7,7 +7,8 @@ Press the following keys in their given circumstances to access menus or perform
 
 Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT on the Wii U Menu
 Skip modifications: Hold <:3ds_button_r:295004508294086656> on bootup
-Environment Loader: Hold <:3ds_button_x:295004476056535041> on bootup
+EnvironmentLoader: Hold the <:3ds_button_x:295004476056535041> button on boot up.
+
 PayloadLoader: Hold the <:3ds_button_b:295004466963283968> button on boot up.
 
 Aroma Boot Selector: Hold the START button on boot up.

--- a/cogs/assistance-cmds/hotkey.wiiu.md
+++ b/cogs/assistance-cmds/hotkey.wiiu.md
@@ -5,7 +5,8 @@ aliases: uhotkeys,uhotkey,wiiuhotkeys,wiiucombo
 ---
 Press the following keys in their given circumstances to access menus or perform actions.
 
-Aroma Plugin Menu: Press <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT on the Wii U Menu
+Aroma Plugin Menu: Press the <:3ds_button_l:295004499511214080> + <:3ds_dpad_down:295004561670930432> + SELECT buttons on the Wii U Menu.
+
 Skip modifications: Hold the <:3ds_button_r:295004508294086656> button on boot up.
 
 EnvironmentLoader: Hold the <:3ds_button_x:295004476056535041> button on boot up.

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -7,7 +7,8 @@ help-desc: Potential fixes for when payload.elf fails to load on the Wii U
 
 - Make sure you have both a `payload.elf` and `payload.rpx` file on your SD card in the `wiiu` folder. Make sure your SD card layout is the same as [this](https://wiiu.eiphax.tech/sdlayout)
 - Redownload the payloads from https://aroma.foryour.cafe/. Extract them onto your SD card, merge the Wii U folder. If prompted to replace the existing ones, do so.
-- Make sure your SD card is properly formatted to Fat32. Type .sdformat for a guide on how to properly format your SD card to Fat32.
+- Make sure your SD card is properly formatted to FAT32. A guide on how to do so can be found [here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
+
 - Make sure your SD card and SD card slot are clean. Power off your console, remove the SD card, and ensure that there is no dust or dirt obstructing the SD card's contacts or the SD card slot.
 - Try saving a Mii to the SD card in Mii Maker. ([Guide](https://en-americas-support.nintendo.com/app/answers/detail/a_id/1722/~/how-to-save-a-mii-as-a-photo))
 - Make sure your SD card is properly inserted into the SD cart slot. You should hear a click sound when it is inserted.

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -6,7 +6,8 @@ help-desc: Potential fixes for when payload.elf fails to load on the Wii U
 **Fixes for "Failed to load payload.elf"**
 
 - Make sure you have both a `payload.elf` and `payload.rpx` file on your SD card in the `wiiu` folder. Make sure your SD card layout is the same as [this](https://wiiu.eiphax.tech/sdlayout)
-- Redownload the payloads from https://aroma.foryour.cafe/. Extract them onto your SD card, merge the Wii U folder. If prompted to replace the existing ones, do so.
+- Redownload the payloads from https://aroma.foryour.cafe/. Extract the contents of the `.zip` file to the root of your SD card, and merge with the existing `wiiu` folder. When prompted to replace the existing ones, do so.
+
 - Make sure your SD card is properly formatted to FAT32. A guide on how to do so can be found [here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
 
 - Make sure your SD card and SD card slot are clean. Power off your console, remove the SD card, and ensure that there is no dust or dirt obstructing the SD card's contacts or the SD card slot.

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -9,6 +9,7 @@ help-desc: Potential fixes for when payload.elf fails to load on the Wii U
 - Redownload the payloads from https://aroma.foryour.cafe/. Extract them onto your SD card, merge the Wii U folder. If prompted to replace the existing ones, do so.
 - Make sure your SD card is properly formatted to Fat32. Type .sdformat for a guide on how to properly format your SD card to Fat32.
 - Make sure your SD card and SD card slot are clean. Power off your console, remove the SD card, and ensure that there is no dust or dirt obstructing the SD card's contacts or the SD card slot.
+- Try saving a Mii to the SD card in Mii Maker. ([Guide](https://en-americas-support.nintendo.com/app/answers/detail/a_id/1722/~/how-to-save-a-mii-as-a-photo))
 - Make sure your SD card is properly inserted into the SD cart slot. You should hear a click sound when it is inserted.
 
 If none of the above works, you may have a faulty/worn SD card, MicroSD card, or MicroSD card adapter, and are advised to purchase a new SD card or adapter. Type .sdreq for SD card size recommendations. 

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -12,4 +12,4 @@ help-desc: Potential fixes for when payload.elf fails to load on the Wii U
 - Try saving a Mii to the SD card in Mii Maker. ([Guide](https://en-americas-support.nintendo.com/app/answers/detail/a_id/1722/~/how-to-save-a-mii-as-a-photo))
 - Make sure your SD card is properly inserted into the SD cart slot. You should hear a click sound when it is inserted.
 
-If none of the above works, you may have a faulty/worn SD card, MicroSD card, or MicroSD card adapter, and are advised to purchase a new SD card or adapter. Type .sdreq for SD card size recommendations. 
+If none of the above works, you may have a faulty/worn SD card, MicroSD card, or MicroSD card adapter, and are advised to purchase a new SD card or adapter. Type `.sdreq` in <#261581918653513729> for SD card size recommendations. 

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -1,0 +1,14 @@
+---
+title: Payload failing to load fixes
+help-desc: Potential fixes for when payload.elf fails to load on the Wii U
+---
+
+**Fixes for "Failed to load payload.elf"**
+
+- Make sure you have both a `payload.elf` and `payload.rpx` file on your SD card in the `wiiu` folder. Make sure your SD card layout is the same as [this](https://wiiu.eiphax.tech/sdlayout)
+- Redownload the payloads from https://aroma.foryour.cafe/. Extract them onto your SD card, merge the Wii U folder. If prompted to replace the existing ones, do so.
+- Make sure your SD card is properly formatted to Fat32. Type .sdformat for a guide on how to properly format your SD card to Fat32.
+- Make sure your SD card and SD card slot are clean. Power off your console, remove the SD card, and ensure that there is no dust or dirt obstructing the SD card's contacts or the SD card slot.
+- Make sure your SD card is properly inserted into the SD cart slot. You should hear a click sound when it is inserted.
+
+If none of the above works, you may have a faulty/worn SD card, MicroSD card, or MicroSD card adapter, and are advised to purchase a new SD card or adapter. Type .sdreq for SD card size recommendations. 

--- a/cogs/assistance-cmds/payloadfail.wiiu.md
+++ b/cogs/assistance-cmds/payloadfail.wiiu.md
@@ -5,7 +5,8 @@ help-desc: Potential fixes for when payload.elf fails to load on the Wii U
 
 **Fixes for "Failed to load payload.elf"**
 
-- Make sure you have both a `payload.elf` and `payload.rpx` file on your SD card in the `wiiu` folder. Make sure your SD card layout is the same as [this](https://wiiu.eiphax.tech/sdlayout)
+- Make sure you have both a `payload.elf` and `payload.rpx` file in the `wiiu` folder on the SD card. Make sure your SD card layout is the same as shown [here](https://wiiu.eiphax.tech/sdlayout).
+
 - Redownload the payloads from https://aroma.foryour.cafe/. Extract the contents of the `.zip` file to the root of your SD card, and merge with the existing `wiiu` folder. When prompted to replace the existing ones, do so.
 
 - Make sure your SD card is properly formatted to FAT32. A guide on how to do so can be found [here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).


### PR DESCRIPTION
2 additional commands that will improve Wii U assistance, by making it easier to inform people of various hotkeys, and allowing for the quick listing of many potential solutions to a common issue where payload.elf fails to load on bootup.
