### PR TITLE
Added .board, .hardware subcommand hwtest

### DIFF
--- a/cogs/assistance-cmds/hardware/hwtest.hardware.md
+++ b/cogs/assistance-cmds/hardware/hwtest.hardware.md
@@ -1,0 +1,15 @@
+---
+title: Ram Hardware Test for 3DS
+help-desc: Testing 3DS RAM
+aliases: 3dsram
+---
+
+Is your 3DS having strange issues or just not able to boot properly? Consider running an Hardware Test to verify you RAM is fine.
+- Run [Hardware Test](https://wiki.hacks.guide/wiki/3DS:Hardware_test) using this guide. 
+Please note if you are unmodded your only option is to run using [ntrboot](https://3ds.hacks.guide/ntrboot)
+Once this test have completed, if you have `0 errors` you are good, otherwise you will need to replace the RAM.
+If you have more than `0 errors` you really only have one option, and that is to backup what you can and replace the motherboard. 
+If you need help with transfering to your new system/board ask in, https://discord.com/channels/196618637950451712/196635695958196224
+
+*While its technically possible to replace the RAM, its very time consuming, requires a donor board, and would likely end up costing more than a replacment board, or a while replacment 3DS.*
+*If this is an N2DSXL, it may be worth looking into a repair from [Nintendo](https://www.nintendo.com/)*

--- a/cogs/assistancehardware.py
+++ b/cogs/assistancehardware.py
@@ -165,6 +165,16 @@ alias = {
     "jan": "new2dsxl",
 }
 
+boards = {
+    "dslite": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-dsl.png",
+    "dsixl": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-dsixl.png",
+    "o3ds": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-o3ds.jpg",
+    "o3dsxl": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-o3dsxl.png",
+    "n3ds": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-n3ds.png",
+    "n3dsxl": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-n3dsxl.png",
+    "n2dsxl": "https://hacksguidewiki.sfo3.digitaloceanspaces.com/hardwarewiki/Board-n2dsxl.png",
+}
+
 
 class AssistanceHardware(commands.Cog):
     """
@@ -189,6 +199,7 @@ class AssistanceHardware(commands.Cog):
     @commands.dynamic_cooldown(KurisuCooldown(1, 5), commands.BucketType.channel)
     @commands.command()
     async def fix(self, ctx: KurisuContext, console=''):
+        """Links to one of multiple ifixit guides"""
         console = console.lower()
         if console in consoles.keys():
             await simple_embed(ctx, consoles[console], color=discord.Color.blue())
@@ -197,7 +208,18 @@ class AssistanceHardware(commands.Cog):
         else:
             await simple_embed(ctx, "Invalid console, see https://www.ifixit.com/Device/Game_Console",
                                color=discord.Color.red())
-
+            
+    @commands.dynamic_cooldown(KurisuCooldown(1, 5), commands.BucketType.channel)
+    @commands.command()
+    async def board(self, ctx: KurisuContext, console=''):
+        """Board diagram for the given console."""
+        console = console.lower()
+        if console in boards.keys():
+            await ctx.send(ctx, "", image_link=boards[console])
+        elif console in alias.keys():
+            await ctx.send(ctx, "", image_link=boards[alias[console]])
+        else:
+            await ctx.send(f'{ctx.author.mention}, Board options are `' +', '.join(boards) + "`",  delete_after=10)
 
 add_md_files_as_commands(AssistanceHardware, join(AssistanceHardware.data_dir, 'hardware'),
                          namespace=AssistanceHardware.hardware)  # type: ignore

--- a/cogs/assistancehardware.py
+++ b/cogs/assistancehardware.py
@@ -208,7 +208,7 @@ class AssistanceHardware(commands.Cog):
         else:
             await simple_embed(ctx, "Invalid console, see https://www.ifixit.com/Device/Game_Console",
                                color=discord.Color.red())
-            
+
     @commands.dynamic_cooldown(KurisuCooldown(1, 5), commands.BucketType.channel)
     @commands.command()
     async def board(self, ctx: KurisuContext, console=''):
@@ -219,7 +219,8 @@ class AssistanceHardware(commands.Cog):
         elif console in alias.keys():
             await ctx.send(ctx, "", image_link=boards[alias[console]])
         else:
-            await ctx.send(f'{ctx.author.mention}, Board options are `' +', '.join(boards) + "`",  delete_after=10)
+            await ctx.send(f'{ctx.author.mention}, Board options are `' + ', '.join(boards) + "`",  delete_after=10)
+
 
 add_md_files_as_commands(AssistanceHardware, join(AssistanceHardware.data_dir, 'hardware'),
                          namespace=AssistanceHardware.hardware)  # type: ignore


### PR DESCRIPTION
- Adds .board commands to replace the .tag board-X commands.
- Added .hardware hwtest, to avoid having to explain bad ram, and how to test it


![Running](https://github.com/user-attachments/assets/9460e618-e121-472c-bf4f-42fd96a4199e)
