### PR TITLE
Remove outdated info from Wii router command

### DIFF
--- a/cogs/assistance-cmds/router.wii.md
+++ b/cogs/assistance-cmds/router.wii.md
@@ -10,6 +10,6 @@ Known routers incompatible with these settings:
 - Spectrum
 
 If your ISP will not let you change these settings, you have a few options:
-- You can try a hotspot. This is not recommended as it usually results in an unstable connection.
-- You can use a LAN adapter. It must have the ASIX AX88772 Chipset or say “compatible with Wii”. Here’s a recommended LAN adapter by uGreen: https://a.co/d/3OcSJDS
-- Alternatively, you can buy a router and just use the isp you already have, like a mesh network. Here’s a cheap router that should work for the Wii: https://www.walmart.com/ip/Netis-WF2412-Wireless-router-4-port-switch-802-11b-g-n-2-4-GHz/37406393
+- You can try a hotspot. This is not recommended, as it usually results in an unstable connection.
+- You can use a LAN adapter. It must have the ASIX AX88772 Chipset or say “compatible with Wii”.
+- Alternatively, you can buy a cheap router and use the ISP you already have, like a mesh network.


### PR DESCRIPTION
The current `.router wii` command links to a LAN adapter on Amazon that no longer works with Wiis. Removed this link, as well as a few other grammatical touch-ups.