### PR TITLE
switch update things ?

### DIFF
--- a/cogs/assistance-cmds/90dns.switch.md
+++ b/cogs/assistance-cmds/90dns.switch.md
@@ -8,6 +8,6 @@ The public 90DNS IP addresses are:
 - `207.246.121.77` (USA)
 - `163.172.141.219`(France)
 
-[Follow these steps](https://switch.hacks.guide/extras/blocking_nintendo/) to set up 90dns and ensure it isn't being blocked
+[Follow these steps](https://switch.hacks.guide/extras/blocking_nintendo) to set up 90dns and ensure it isn't being blocked
 
 You will have to manually set these for each Wi-Fi connection you have set up.

--- a/cogs/assistance-cmds/autorcm.switch.md
+++ b/cogs/assistance-cmds/autorcm.switch.md
@@ -1,6 +1,6 @@
 ---
 title: Guide
-url: https://switch.hacks.guide/extras/autorcm/
+url: https://switch.hacks.guide/extras/autorcm
 author.name: NH Discord Server
 thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
 help-desc: Guide and Warnings about AutoRCM

--- a/cogs/assistance-cmds/dnsmitm.switch.md
+++ b/cogs/assistance-cmds/dnsmitm.switch.md
@@ -5,4 +5,4 @@ help-desc: Applying AMS DNS redirection
 
 To ensure that your emuMMC/emuNAND does not connect to Nintendo, you should use DNS.mitm (AMS DNS redirection).
 
-[Follow these steps](https://switch.hacks.guide/extras/blocking_nintendo/) to set up DNS.mitm on your emuMMC/emuNAND and automatically redirect any requests directed to Nintendo to nothing instead.
+[Follow these steps](https://switch.hacks.guide/extras/blocking_nintendo) to set up DNS.mitm on your emuMMC/emuNAND and automatically redirect any requests directed to Nintendo to nothing instead.

--- a/cogs/assistance-cmds/incognito.switch.md
+++ b/cogs/assistance-cmds/incognito.switch.md
@@ -10,4 +10,4 @@ Incognito isn't an effective method for ban prevention.
 - On system versions 17.0.0 and above, Incognito will cause a crash when trying to connect to the internet.
 - Traces of Incognito remain on the system even *after* it is disabled, which works against the point of Incognito safeguarding you in the first place.
 
-90DNS / dns.mitm are both more effective methods at ban prevention since they completely prevent the Switch from connecting to Nintendo. Instructions for their use can be found here: https://switch.hacks.guide/extras/blocking_nintendo/
+90DNS / dns.mitm are both more effective methods at ban prevention since they completely prevent the Switch from connecting to Nintendo. Instructions for their use can be found here: https://switch.hacks.guide/extras/blocking_nintendo

--- a/cogs/assistance-cmds/injectors.switch.md
+++ b/cogs/assistance-cmds/injectors.switch.md
@@ -1,10 +1,10 @@
 ---
 title: List of switch payload injectors
 help-desc: List of switch payload injectors
-url: https://switch.hacks.guide/extras/rcm_injectors/
+url: https://switch.hacks.guide/extras/rcm_injectors
 thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
 author.name: NH Discord Server
-author.url: https://switch.hacks.guide/extras/rcm_injectors/
+author.url: https://switch.hacks.guide/extras/rcm_injectors
 aliases: injector
 ---
 

--- a/cogs/assistance-cmds/transfersd.switch.md
+++ b/cogs/assistance-cmds/transfersd.switch.md
@@ -1,6 +1,6 @@
 ---
 title: Moving SD cards
-url: https://switch.hacks.guide/extras/transfer_sd/
+url: https://switch.hacks.guide/extras/transfer_sd
 thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
 author.name: NH Discord Server
 author.url: https://switch.hacks.guide/

--- a/cogs/assistance-cmds/tutorial/layeredfs.switch.md
+++ b/cogs/assistance-cmds/tutorial/layeredfs.switch.md
@@ -1,8 +1,8 @@
 ---
 title: LayeredFS Guide
-url: https://switch.hacks.guide/extras/game_modding/
+url: https://switch.hacks.guide/extras/game_modding
 author.name: NH Discord Server
-author.url: https://switch.hacks.guide/extras/game_modding/
+author.url: https://switch.hacks.guide/extras/game_modding
 thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
 help-desc: How to use Atmosphere's LayeredFS for game modding.
 ---

--- a/cogs/assistance-cmds/tutorial/themes.switch.md
+++ b/cogs/assistance-cmds/tutorial/themes.switch.md
@@ -3,7 +3,7 @@ title: Switch Themes
 help-desc: Links to tutorials for installing themes
 ---
 
-[Theme installation guide](https://switch.hacks.guide/homebrew/nxtheme-installer/)
+[Theme installation guide](https://switch.hacks.guide/homebrew/nxtheme-installer)
 
 Theme repositories:
 - [themezer](https://themezer.net/)

--- a/utils/mdcmd.py
+++ b/utils/mdcmd.py
@@ -31,10 +31,10 @@ for k, v in aliases.items():
 systems = systems_no_aliases + tuple(aliases) + ('legacy',)
 
 format_map = {
-    'nx_firmware': '18.0.0',
-    'ams_ver': '1.6.2',
-    'hekate_ver': '6.1.0',
-    'last_revision': '26th March, 2024',
+    'nx_firmware': '19.0.1',
+    'ams_ver': '1.8.0',
+    'hekate_ver': '6.2.2',
+    'last_revision': '7th March, 2025',
 }
 
 


### PR DESCRIPTION
fixed some funky links that lead to a blank page within a lot of tutorials due to having a / at the end of the url certified vitepress moment updated the switch version number references in some commands presumably ok cool bye