### PR TITLE
Fixed edge case causing errors with .board command

### DIFF
--- a/cogs/assistancehardware.py
+++ b/cogs/assistancehardware.py
@@ -240,6 +240,7 @@ class AssistanceHardware(commands.Cog):
                 embed.description = f'{ctx.author.mention}, Board options are `' + ', '.join(boards) + "`"
                 embed.color = discord.Color.red()
                 await ctx.send(embed=embed, delete_after=10)
+                return
         else:
             embed.description = f'{ctx.author.mention}, Board options are `' + ', '.join(boards) + "`"
             embed.color = discord.Color.red()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/93d329f4-f9a9-45fe-905c-309c52fc193a)

Fix for this.