### PR TITLE
Initial implementation of "title.txt" parser cog

### DIFF
--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -404,24 +404,37 @@ class TitleTXTParser(commands.Cog):
                     bad_titles = self.bad_titles(parsed_tree)
                     bad_folders = self.bad_folders(parsed_tree)
                 except MultipleID1Exception:
-                    out_message = "You appear to have multiple ID1 folders! "
+                    if len(message.attachments) > 1:
+                        out_message = f"{message.author.mention}: `{f.filename}`: You appear to have multiple ID1 folders! "
+                    else:
+                        out_message = f"{message.author.mention} You appear to have multiple ID1 folders! "
                     out_message += "Please [fix this](<https://wiki.hacks.guide/wiki/3DS:MID1>) and then try again."
                     await message.reply(out_message)
-                    return
+                    continue
 
                 if bad_titles is None:
                     # Happens if no "00040000" folder is found
-                    out_message = f"{message.author.mention} This doesn't look correct. Are you sure you're running the `tree` command in the right folder?"
+                    if len(message.attachments) > 1:
+                        out_message = f"{message.author.mention}: `{f.filename}`: This doesn't look correct. Are you sure you're running the `tree` command in the right folder?"
+                    else:
+                        out_message = f"{message.author.mention} This doesn't look correct. Are you sure you're running the `tree` command in the right folder?"
                     await message.reply(out_message)
-                    return
+                    continue
 
                 if len(bad_titles) == 0:
                     # no issues found
-                    out_message = f"{message.author.mention} This `title.txt` appears to be OK. Your HOME Menu issues are not likely to be caused by missing data."
+                    if len(message.attachments) > 1:
+                        out_message = f"{message.author.mention}: `{f.filename}`: This `title.txt` appears to be OK. Your HOME Menu issues are not likely to be caused by missing data."
+                    else:
+                        out_message = f"{message.author.mention}: This `title.txt` appears to be OK. Your HOME Menu issues are not likely to be caused by missing data."
                     await message.reply(out_message)
-                    return
+                    continue
 
-                out_message = f"{message.author.mention} Missing data was found in this `title.txt` which may be causing issues.\n\n"
+                if len(message.attachments) > 1:
+                    out_message = f"{message.author.mention}: `{f.filename}`: Missing data was found in this `title.txt` which may be causing issues.\n\n"
+                else:
+                    out_message = f"{message.author.mention} Missing data was found in this `title.txt` which may be causing issues.\n\n"
+
                 title_counter = 0
                 total_title_count = sum(len(folder) for folder in bad_titles)
 

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -237,7 +237,6 @@ class TitleTXTParser(commands.Cog):
                 if not isinstance(content_folder, dict):
                     # file, maybe tmd
                     if ".tmd" in content_folder_id:
-                        logger.debug("tmd OK for %s", title_id)
                         flag_tmd_ok = True
                     continue
 
@@ -251,7 +250,6 @@ class TitleTXTParser(commands.Cog):
 
                 for file in content_folder:
                     if ".app" in file:
-                        logger.debug("app OK for %s", title_id)
                         flag_app_ok = True
 
             if title_id in bad_titles:
@@ -259,11 +257,7 @@ class TitleTXTParser(commands.Cog):
                 break
 
             if not (flag_app_ok and flag_tmd_ok):
-                logger.debug("%s not ok", title_id)
-                logger.debug("app %s tmd %s", flag_app_ok, flag_tmd_ok)
                 bad_titles.append(title_id)
-
-            logger.debug("---")
 
         return bad_titles
 
@@ -276,7 +270,14 @@ class TitleTXTParser(commands.Cog):
         """
 
         if "00040000" not in in_tree:
-            return None
+            if "title" in in_tree and "dbs" in in_tree:
+                # oops! helpee ran tree from id1
+                # no big deal, easy to work around
+                # just dig down a layer
+                # thanks for the suggestion, Karma
+                in_tree = in_tree["title"]
+            else:
+                return None
 
         bad_titles = dict()
         for folder_name, folder in in_tree.items():

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -35,6 +35,8 @@ _TREE_FILE_RE = re.compile(r"[\| ]+(\S+)")
 
 _HEX_RE = re.compile(r"[0-9a-fA-F]")
 
+_TITLE_TXT_RE = re.compile(r"[TtIiLlEe]{4,}.+\.[tx]{3,}")
+
 
 def parse_tree(lines: list[str]) -> tuple[dict, bool]:
     """
@@ -310,7 +312,7 @@ class TitleTXTParser(commands.Cog):
         Message handler for the TitleTXT parser cog.
         """
         for f in message.attachments:
-            if f.filename.lower() == "title.txt":
+            if _TITLE_TXT_RE.match(f.filename):
                 async with self.bot.session.get(f.url, timeout=45) as titletxt_request:
                     titletxt_content = await titletxt_request.read()
                     titletxt_lines = titletxt_content.decode(

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -351,7 +351,11 @@ class TitleTXTParser(commands.Cog):
                                 return None
 
         for item_name, item in directory.items():
-            if isinstance(item, dict) and _HEX_RE.match(item_name):
+            if (
+                isinstance(item, dict)
+                and _HEX_RE.match(item_name)
+                and len(item_name) > 8  # catch running from 00040000
+            ):
                 # id0 or id1
                 for subitem_name, subitem in item.items():
                     if isinstance(subitem, dict) and subitem_name == "title":

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -1,0 +1,281 @@
+import discord
+import concurrent.futures
+import logging
+import functools
+import re
+
+from discord.ext import commands, tasks
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+if TYPE_CHECKING:
+    from kurisu import Kurisu
+
+# max number of broken titles before we bail
+# the most i've seen IRL on a non-dead card was about 5-6
+_MAX_BROKEN_TITLES = 10
+
+
+_TREE_INDENT = (
+    " " * 3
+)  # Windows TREE uses three spaces for indents, instead of the usual four
+_TREE_DIRECTORY_RE = re.compile(r"[\\\+]---(\S+)")
+_TREE_FILE_RE = re.compile(r"[\| ]+(\S+)")
+
+
+def parse_tree(lines: list[str]) -> tuple[dict, bool]:
+    """
+    Parse a directory recursively and return a dictionary representing its contents
+    """
+    directory = {}
+    pos = 0
+    fs_corruption_flag = False
+    while pos < len(lines):
+        line = lines[pos].rstrip()
+        line_indent_level = line.count(_TREE_INDENT)
+        if matchobj := _TREE_DIRECTORY_RE.search(line):
+            dir_name = matchobj.group(1)
+            # seek ahead to find next directory entry
+            seek_pos = pos + 1
+            while seek_pos < len(lines):
+                seek_line = lines[seek_pos]
+                seek_match_obj = _TREE_DIRECTORY_RE.search(seek_line)
+                if seek_match_obj:
+                    seek_indent_level = seek_line.count(_TREE_INDENT)
+                    if seek_indent_level <= line_indent_level:
+                        break
+                    seek_pos = seek_pos + 1
+                else:
+                    seek_pos = seek_pos + 1
+            if seek_pos >= len(lines):
+                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1 :])
+                if fs_corruption_flag is False and fsflag_temp is True:
+                    # this should be burn-once and should never be set back to false once set to true
+                    fs_corruption_flag = True
+            else:
+                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1 : seek_pos])
+                if fs_corruption_flag is False and fsflag_temp is True:
+                    # this should be burn-once and should never be set back to false once set to true
+                    fs_corruption_flag = True
+
+            pos = seek_pos - 1
+        elif matchobj := _TREE_FILE_RE.match(line):
+            file_name = matchobj.group(1)
+            if file_name != "|":
+                directory[file_name] = "(file)"
+        elif line.replace("|", "").strip() == "":
+            # ignore empty lines
+            pass
+        else:
+            # mystery line
+            # usually caused by filesystem corruption (\n in filename doesn't happen normally)
+            fs_corruption_flag = True
+        pos = pos + 1
+
+    return directory, fs_corruption_flag
+
+
+class TitleTXTParser(commands.Cog):
+    """
+    Parse the output of the Tree command (as suggested by the missingtitles tag)
+    and reply with a list of corrupted titles which should be removed
+    """
+
+    def __init__(self, bot: "Kurisu"):
+        self.bot = bot
+        self.titledb = []
+        self.hbdb = []
+        self.tidpull.start()  # Title database code pulled from db3ds
+        self.hbpull.start()
+
+    async def cog_unload(self):
+        self.tidpull.cancel()
+        self.hbpull.cancel()
+
+    @tasks.loop(hours=1)
+    async def tidpull(self):
+        regions = ["GB", "JP", "KR", "TW", "US"]
+        titledb = []
+        for region in regions:
+            async with self.bot.session.get(
+                f"https://raw.githubusercontent.com/hax0kartik/3dsdb/master/jsons/list_{region}.json"
+            ) as r:
+                if r.status == 200:
+                    j = await r.json(content_type=None)
+                    titledb = titledb + j
+                else:
+                    # if any of the JSONs can't be pulled, don't update
+                    # otherwise, it could replace the db with nothing,
+                    # and old data is better than no data
+                    return
+        self.titledb = titledb
+
+    @tasks.loop(hours=1)
+    async def hbpull(self):
+        async with self.bot.session.get(
+            "https://db.universal-team.net/data/full.json"
+        ) as r:
+            if r.status == 200:
+                logging.debug("homebrew database is ready")
+                self.hbdb = await r.json(content_type=None)
+            else:
+                # old data better than no data
+                return
+
+    def get_game_by_tidlow(self, tidlow: str) -> str | None:
+        """
+        Get a title's name by it's TIDlow, as used in the 3DS folder structure
+        """
+        full_tid = f"00040000{tidlow.upper()}"
+        for title in self.titledb:
+            if title["TitleID"] == full_tid:
+                return title["Name"]
+
+        return None
+
+    def get_hb_by_tidlow(self, tidlow: str) -> str | None:
+        """
+        Get a homebrew app's name by it's TIDlow
+        """
+        for title in self.hbdb:
+            if "systems" in title and "3DS" in title["systems"]:
+                if "unique_ids" in title:
+                    for uid in title["unique_ids"]:
+                        if f"{uid:x}" in tidlow:  # padding can get funky...
+                            return title["title"]
+
+        return None
+
+    def get_name_by_tidlow(self, tidlow: str) -> str | None:
+        """
+        Try both the homebrew and game databases
+        """
+        name = self.get_game_by_tidlow(tidlow)
+        if name is None:
+            name = self.get_hb_by_tidlow(tidlow)
+
+        return name
+
+    @staticmethod
+    def bad_titles(directory: dict) -> list[str] | None:
+        """
+        Further examine the output of parse_dir to get a list of 3DS titles
+        which may be missing data.
+
+        Returns None if the 0040000 folder is missing (filename match may be a false positive)
+        """
+
+        if "00040000" not in directory:
+            return None
+
+        bad_titles = []
+        for name, item in directory["00040000"].items():
+            if not isinstance(item, dict):
+                pass
+
+            flag_ticket_ok = False
+            flag_app_ok = False
+            if "content" not in item:
+                bad_titles.append(name)
+                continue
+
+            for item_name in item["content"]:
+                if ".app" in item_name:
+                    flag_app_ok = True
+                elif "tmd" in item_name:
+                    flag_ticket_ok = True
+
+            if not (flag_app_ok and flag_ticket_ok):
+                bad_titles.append(name)
+
+        return bad_titles
+
+    @staticmethod
+    def bad_folders(directory: dict) -> list[str]:
+        """
+        Check for empty folders which may be causing issues
+        """
+        bad_folders = []
+        for name, entry in directory.items():
+            if isinstance(entry, dict):
+                if len(entry) == 0:
+                    bad_folders.append(name)
+
+        return bad_folders
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        """
+        Message handler for the TitleTXT parser cog.
+        """
+        for f in message.attachments:
+            if f.filename.lower() == "title.txt":
+                async with self.bot.session.get(f.url, timeout=45) as titletxt_request:
+                    titletxt_content = await titletxt_request.read()
+                    titletxt_lines = titletxt_content.decode(
+                        encoding="utf-16"
+                    ).splitlines()
+                    with concurrent.futures.ProcessPoolExecutor() as pool:
+                        parsed_tree, fs_corruption_flag = (
+                            await self.bot.loop.run_in_executor(
+                                pool,
+                                functools.partial(
+                                    parse_tree, titletxt_lines[3:]
+                                ),  # skip the first three lines - header and volume info
+                            )
+                        )
+                        bad_titles = await self.bot.loop.run_in_executor(
+                            pool,
+                            functools.partial(self.bad_titles, parsed_tree),
+                        )
+                        bad_folders = await self.bot.loop.run_in_executor(
+                            pool,
+                            functools.partial(self.bad_folders, parsed_tree),
+                        )
+
+                if bad_titles is None:
+                    # Happens if no "00040000" folder is found
+                    out_message = f"{message.author.mention} This doesn't look correct. Are you sure you're running the `tree` command in the right folder?"
+                    await message.reply(out_message)
+                    return
+
+                if len(bad_titles) == 0:
+                    # no issues found
+                    out_message = f"{message.author.mention} This `title.txt` appears to be OK. Your HOME Menu issues are not likely to be caused by missing data."
+                    await message.reply(out_message)
+                    return
+                out_message = f"{message.author.mention} Missing data was found in this `title.txt` which may be causing issues.\n\n"
+                out_message += "Copy the following folders from the `00040000` folder inside the `title` folder to your computer, then delete them from your SD card:\n"
+
+                for counter, title in enumerate(bad_titles):
+                    title_name = self.get_name_by_tidlow(title)
+                    if title_name:
+                        out_message += f"- `{title}` ({title_name})\n"
+                    else:
+                        out_message += f"- `{title}`\n"
+
+                    if counter > _MAX_BROKEN_TITLES:
+                        remaining = len(bad_titles) - _MAX_BROKEN_TITLES
+                        out_message += f"...and {remaining} more "
+                        out_message += " (send another title.txt once you've removed the above folders for more info)\n"
+                        break
+
+                if len(bad_folders) > 0:
+                    out_message += "Delete the following folders from the `title` folder (no need to copy first):\n"
+                    for bad_folder in bad_folders:
+                        out_message += f"- `{bad_folder}`\n"
+
+                if fs_corruption_flag:
+                    out_message += "\nAdditionally, your SD card appears to contain corrupted data. "
+                    out_message += "We recommend making a backup of your card, then [checking it for issues](https://wiki.hacks.guide/wiki/Checking_SD_card_integrity).\n"
+
+                out_message += "\nOnce you have completed these steps, re-insert the card into your console, and check to see if the HOME Menu loads correctly.\n"
+                out_message += "If not, come back for further assistance, and mention that you have already tried the missingtitles steps."
+
+                await message.reply(out_message)
+
+
+async def setup(bot):
+    await bot.add_cog(TitleTXTParser(bot))

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -236,7 +236,8 @@ class TitleTXTParser(commands.Cog):
             for content_folder_id, content_folder in title["content"].items():
                 if not isinstance(content_folder, dict):
                     # file, maybe tmd
-                    if ".tmd" in content_folder:
+                    if ".tmd" in content_folder_id:
+                        logger.debug("tmd OK for %s", title_id)
                         flag_tmd_ok = True
                     continue
 
@@ -250,6 +251,7 @@ class TitleTXTParser(commands.Cog):
 
                 for file in content_folder:
                     if ".app" in file:
+                        logger.debug("app OK for %s", title_id)
                         flag_app_ok = True
 
             if title_id in bad_titles:
@@ -257,7 +259,11 @@ class TitleTXTParser(commands.Cog):
                 break
 
             if not (flag_app_ok and flag_tmd_ok):
+                logger.debug("%s not ok", title_id)
+                logger.debug("app %s tmd %s", flag_app_ok, flag_tmd_ok)
                 bad_titles.append(title_id)
+
+            logger.debug("---")
 
         return bad_titles
 

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -375,7 +375,7 @@ class TitleTXTParser(commands.Cog):
         return None  # failsafe... what the hell have they done to their SD?
 
     @staticmethod
-    def sanitize(input: str) -> str:
+    def sanitize(input_str: str) -> str:
         """
         Sanitize a string (remove backticks, @ symbols, etc) to prevent exploits.
         """
@@ -386,7 +386,7 @@ class TitleTXTParser(commands.Cog):
             }
         )
 
-        return input.translate(output_replacements)
+        return input_str.translate(output_replacements)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -71,12 +71,12 @@ def parse_tree(lines: list[str]) -> tuple[dict, bool]:
                 else:
                     seek_pos = seek_pos + 1
             if seek_pos >= len(lines):
-                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1 :])
+                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1:])
                 if fs_corruption_flag is False and fsflag_temp is True:
                     # this should be burn-once and should never be set back to false once set to true
                     fs_corruption_flag = True
             else:
-                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1 : seek_pos])
+                directory[dir_name], fsflag_temp = parse_tree(lines[pos + 1:seek_pos])
                 if fs_corruption_flag is False and fsflag_temp is True:
                     # this should be burn-once and should never be set back to false once set to true
                     fs_corruption_flag = True
@@ -103,10 +103,11 @@ class MultipleID1Exception(Exception):
     Exception thrown when multiple ID1s are found
     """
 
+
 class MangledFolderStructure(Exception):
     """
     Exception thrown if 00040000 is not found but other title folders are found
-    Shouldn't happen unless helpee has deleted 
+    Shouldn't happen unless helpee has deleted
     """
 
 
@@ -292,17 +293,15 @@ class TitleTXTParser(commands.Cog):
         Check for mangled folder structure in title folder
         """
         title_folder_count = 0
-        for item_name, item in in_tree.items():
-            logger.debug("%s %s", len(item_name), item_name)
+        for item_name in in_tree.keys():
             if len(item_name) == 8 and item_name.startswith("0004"):
                 title_folder_count += 1
-        
+
         if title_folder_count > 0:
             # helpee has mangled the Title folder, bail and request human intervention
             return True
-        
-        return False
 
+        return False
 
     def bad_titles(self, in_tree: dict) -> list[str] | None:
         """
@@ -325,12 +324,11 @@ class TitleTXTParser(commands.Cog):
                     return None
             else:
                 in_tree = result
-        
+
         # check again for mangled folder structure
         if "00040000" not in in_tree:
             if self.detect_mangled_structure(in_tree):
                 raise MangledFolderStructure()
-
 
         bad_titles = dict()
         for folder_name, folder in in_tree.items():
@@ -412,7 +410,6 @@ class TitleTXTParser(commands.Cog):
                     if "title" in id1:
                         return id1["title"]
 
-        logger.debug("helpee did some weird things to their SD")
         return None  # failsafe... what the hell have they done to their SD?
 
     @staticmethod
@@ -505,7 +502,6 @@ class TitleTXTParser(commands.Cog):
                     out_message += "You will need to either restore a backup of your SD card, or wait for further assistance."
                     await message.reply(out_message, allowed_mentions=_SAFE_MENTIONS)
                     continue
-
 
                 if bad_titles is None:
                     # Happens if no "00040000" folder is found

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         aliases:
           - kurisu_db
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U kurisu" ]
+      test: ["CMD-SHELL", "pg_isready -U kurisu"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,8 +27,8 @@ services:
       SERVER_LOGS_URL_FILE: /run/secrets/server_logs_url
       DB_USER: kurisu
       DB_PASSWORD: dev123
-    # networks:
-    #   - bridge
+    networks:
+      - bridge
     secrets:
       - kurisu_token
       - server_logs_url
@@ -42,7 +42,6 @@ networks:
 
 volumes:
   kurisutestdb:
-
 
 secrets:
   kurisu_token:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         aliases:
           - kurisu_db
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U kurisu"]
+      test: [ "CMD-SHELL", "pg_isready -U kurisu" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,8 +27,8 @@ services:
       SERVER_LOGS_URL_FILE: /run/secrets/server_logs_url
       DB_USER: kurisu
       DB_PASSWORD: dev123
-    networks:
-      - bridge
+    # networks:
+    #   - bridge
     secrets:
       - kurisu_token
       - server_logs_url
@@ -42,6 +42,7 @@ networks:
 
 volumes:
   kurisutestdb:
+
 
 secrets:
   kurisu_token:

--- a/kurisu.py
+++ b/kurisu.py
@@ -22,14 +22,7 @@ from discord.app_commands import AppCommand, AppCommandGroup
 from discord.ext import commands
 from subprocess import check_output, CalledProcessError
 from typing import Optional
-from utils import (
-    WarnsManager,
-    ConfigurationManager,
-    RestrictionsManager,
-    ExtrasManager,
-    FiltersManager,
-    UserLogManager,
-)
+from utils import WarnsManager, ConfigurationManager, RestrictionsManager, ExtrasManager, FiltersManager, UserLogManager
 from utils.checks import InsufficientStaffRank, AppInsufficientStaffRank
 from utils.help import KuriHelp, HelpView, CategorySelect, MainHelpPaginator
 from utils.utils import create_error_embed
@@ -37,98 +30,90 @@ from utils.context import KurisuContext
 from utils.patch import patched_member_convert, patched_user_convert
 
 cogs = (
-    "cogs.assistance",
-    "cogs.assistancewii",
-    "cogs.assistancewiiu",
-    "cogs.assistance3ds",
-    "cogs.assistanceswitch",
-    "cogs.assistancehardware",
-    "cogs.automod",
-    "cogs.blah",
-    "cogs.db3ds",
-    "cogs.events",
-    "cogs.extras",
-    "cogs.filters",
-    "cogs.friendcode",
-    "cogs.kickban",
-    "cogs.load",
-    "cogs.lockdown",
-    "cogs.logs",
-    "cogs.loop",
-    "cogs.memes",
-    "cogs.helperlist",
-    "cogs.imgconvert",
-    "cogs.luma3dsdumpconvert",
-    "cogs.mod_staff",
-    "cogs.mod_warn",
-    "cogs.mod_watch",
-    "cogs.mod",
-    "cogs.results",
-    "cogs.rules",
-    "cogs.ssnc",
-    "cogs.xkcdparse",
-    "cogs.seasonal",
-    "cogs.newcomers",
-    "cogs.server_logs",
-    "cogs.soap",
-    "cogs.titletxtparse",
+    'cogs.assistance',
+    'cogs.assistancewii',
+    'cogs.assistancewiiu',
+    'cogs.assistance3ds',
+    'cogs.assistanceswitch',
+    'cogs.assistancehardware',
+    'cogs.automod',
+    'cogs.blah',
+    'cogs.db3ds',
+    'cogs.events',
+    'cogs.extras',
+    'cogs.filters',
+    'cogs.friendcode',
+    'cogs.kickban',
+    'cogs.load',
+    'cogs.lockdown',
+    'cogs.logs',
+    'cogs.loop',
+    'cogs.memes',
+    'cogs.helperlist',
+    'cogs.imgconvert',
+    'cogs.luma3dsdumpconvert',
+    'cogs.mod_staff',
+    'cogs.mod_warn',
+    'cogs.mod_watch',
+    'cogs.mod',
+    'cogs.results',
+    'cogs.rules',
+    'cogs.ssnc',
+    'cogs.xkcdparse',
+    'cogs.seasonal',
+    'cogs.newcomers',
+    'cogs.server_logs',
+    'cogs.soap',
+    'cogs.titletxtparse'
 )
 
 DEBUG = False
-IS_DOCKER = os.environ.get("IS_DOCKER", "")
+IS_DOCKER = os.environ.get('IS_DOCKER', '')
 
 # monkey patch member and user converters
 commands.MemberConverter.convert = patched_member_convert
 commands.UserConverter.convert = patched_user_convert
 
 if IS_DOCKER:
-
     def get_env(name: str):
         contents = os.environ.get(name)
         if contents is None:
-            contents_file = os.environ.get(name + "_FILE")
+            contents_file = os.environ.get(name + '_FILE')
             if contents_file:
                 try:
-                    with open(contents_file, "r", encoding="utf-8") as f:
+                    with open(contents_file, 'r', encoding='utf-8') as f:
                         contents = f.readline().strip()
                 except FileNotFoundError:
-                    sys.exit(
-                        f"Couldn't find environment variables {name} or {name}_FILE."
-                    )
+                    sys.exit(f"Couldn't find environment variables {name} or {name}_FILE.")
                 except IsADirectoryError:
-                    sys.exit(
-                        f"Attempted to open {contents_file} (env {name}_FILE) but it is a folder."
-                    )
+                    sys.exit(f"Attempted to open {contents_file} (env {name}_FILE) but it is a folder.")
             else:
                 sys.exit(f"Missing {name}.")
 
         return contents
 
-    TOKEN = get_env("KURISU_TOKEN")
-    db_user = get_env("DB_USER")
-    db_password = get_env("DB_PASSWORD")
-    SERVER_LOGS_URL = get_env("SERVER_LOGS_URL")
+    TOKEN = get_env('KURISU_TOKEN')
+    db_user = get_env('DB_USER')
+    db_password = get_env('DB_PASSWORD')
+    SERVER_LOGS_URL = get_env('SERVER_LOGS_URL')
     DATABASE_URL = f"postgresql://{db_user}:{db_password}@kurisu_db/{db_user}"
 else:
     kurisu_config = ConfigParser()
     kurisu_config.read("data/config.ini")
-    TOKEN = kurisu_config["Main"]["token"]
-    DATABASE_URL = kurisu_config["Main"]["database_url"]
-    SERVER_LOGS_URL = kurisu_config["Main"]["server_logs_url"]
+    TOKEN = kurisu_config['Main']['token']
+    DATABASE_URL = kurisu_config['Main']['database_url']
+    SERVER_LOGS_URL = kurisu_config['Main']['server_logs_url']
 
 
 def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.INFO)
-    fmt = logging.Formatter(
-        "[{asctime}] [{levelname:^7s}] {name}.{funcName}: {message}",
-        datefmt="%Y-%m-%d %H:%M:%S",
-        style="{",
-    )
+    fmt = logging.Formatter('[{asctime}] [{levelname:^7s}] {name}.{funcName}: {message}', datefmt="%Y-%m-%d %H:%M:%S",
+                            style='{')
     sh = logging.StreamHandler()
     sh.setFormatter(fmt)
     log.addHandler(sh)
-    logging.getLogger("discord").propagate = False
+    logging.getLogger('discord').propagate = False
 
 
 logger = logging.getLogger(__name__)
@@ -139,19 +124,11 @@ class Kurisu(commands.Bot):
     user: discord.ClientUser
     pool: asyncpg.Pool
     db_closed: bool
-    tree: "Kuritree"
+    tree: 'Kuritree'
 
     def __init__(self, command_prefix, description, commit, branch, pool):
-        intents = discord.Intents(
-            guilds=True,
-            members=True,
-            messages=True,
-            reactions=True,
-            bans=True,
-            message_content=True,
-            auto_moderation_execution=True,
-            emojis=True,
-        )
+        intents = discord.Intents(guilds=True, members=True, messages=True, reactions=True, bans=True,
+                                  message_content=True, auto_moderation_execution=True, emojis=True)
         allowed_mentions = discord.AllowedMentions(everyone=False, roles=False)
         super().__init__(
             command_prefix=commands.when_mentioned_or(*command_prefix),
@@ -159,10 +136,10 @@ class Kurisu(commands.Bot):
             intents=intents,
             allowed_mentions=allowed_mentions,
             case_insensitive=True,
-            tree_cls=Kuritree,
+            tree_cls=Kuritree
         )
 
-        self.tz = pytz.timezone("US/Pacific")
+        self.tz = pytz.timezone('US/Pacific')
         self.startup = datetime.now(self.tz)
         self.IS_DOCKER = IS_DOCKER
         self.commit = commit
@@ -170,9 +147,7 @@ class Kurisu(commands.Bot):
 
         self.roles: dict[str, discord.Role] = {}
 
-        self.channels: dict[
-            str, discord.TextChannel | discord.VoiceChannel | discord.Thread
-        ] = {}
+        self.channels: dict[str, discord.TextChannel | discord.VoiceChannel | discord.Thread] = {}
 
         self.failed_cogs = []
         self.channels_not_found = []
@@ -193,7 +168,7 @@ class Kurisu(commands.Bot):
         self.actions = []
         self.pruning = False
         self.emoji = discord.PartialEmoji.from_str("⁉")
-        self.colour = discord.Colour(0xB01EC3)
+        self.colour = discord.Colour(0xb01ec3)
 
         self._is_all_ready = asyncio.Event()
 
@@ -201,9 +176,7 @@ class Kurisu(commands.Bot):
         self.session = aiohttp.ClientSession()
         await self.load_cogs()
 
-    async def get_context(
-        self, origin: discord.Interaction | discord.Message, /, *, cls=KurisuContext
-    ) -> KurisuContext:
+    async def get_context(self, origin: discord.Interaction | discord.Message, /, *, cls=KurisuContext) -> KurisuContext:
         return await super().get_context(origin, cls=cls)
 
     async def on_ready(self):
@@ -212,85 +185,65 @@ class Kurisu(commands.Bot):
 
         self.guild = self.guilds[0]
 
-        self.emoji = discord.utils.get(
-            self.guild.emojis, name="kurisu"
-        ) or discord.PartialEmoji.from_str("⁉")
+        self.emoji = discord.utils.get(self.guild.emojis, name='kurisu') or discord.PartialEmoji.from_str("⁉")
 
         # Load channels and roles
         await self.load_channels()
         await self.load_roles()
 
-        self.helper_roles: dict[str, discord.Role] = {
-            "3DS": self.roles["On-Duty 3DS"],
-            "WiiU": self.roles["On-Duty Wii U"],
-            "Switch": self.roles["On-Duty Switch"],
-            "Legacy": self.roles["On-Duty Legacy"],
-            "Wii": self.roles["On-Duty Wii"],
-        }
+        self.helper_roles: dict[str, discord.Role] = {"3DS": self.roles['On-Duty 3DS'],
+                                                      "WiiU": self.roles['On-Duty Wii U'],
+                                                      "Switch": self.roles['On-Duty Switch'],
+                                                      "Legacy": self.roles['On-Duty Legacy'],
+                                                      "Wii": self.roles['On-Duty Wii']
+                                                      }
 
-        self.assistance_channels: tuple[
-            discord.TextChannel | discord.VoiceChannel, ...
-        ] = (
-            self.channels["3ds-assistance-1"],
-            self.channels["3ds-assistance-2"],
-            self.channels["wiiu-assistance"],
-            self.channels["switch-assistance-1"],
-            self.channels["switch-assistance-2"],
-            self.channels["hacking-general"],
-            self.channels["legacy-systems"],
-            self.channels["tech-talk"],
-            self.channels["hardware"],
+        self.assistance_channels: tuple[discord.TextChannel | discord.VoiceChannel, ...] = (
+            self.channels['3ds-assistance-1'],
+            self.channels['3ds-assistance-2'],
+            self.channels['wiiu-assistance'],
+            self.channels['switch-assistance-1'],
+            self.channels['switch-assistance-2'],
+            self.channels['hacking-general'],
+            self.channels['legacy-systems'],
+            self.channels['tech-talk'],
+            self.channels['hardware'],
         )
 
-        self.staff_roles: dict[str, discord.Role] = {
-            "Owner": self.roles["Owner"],
-            "SuperOP": self.roles["SuperOP"],
-            "OP": self.roles["OP"],
-            "HalfOP": self.roles["HalfOP"],
-        }
+        self.staff_roles: dict[str, discord.Role] = {'Owner': self.roles['Owner'],
+                                                     'SuperOP': self.roles['SuperOP'],
+                                                     'OP': self.roles['OP'],
+                                                     'HalfOP': self.roles['HalfOP'],
+                                                     }
 
-        self.err_channel = self.channels["bot-err"]
+        self.err_channel = self.channels['bot-err']
         self.tree.err_channel = self.err_channel
 
-        startup_message = f"{self.user.name} has started! {self.guild} has {self.guild.member_count:,} members!"
-        embed = discord.Embed(
-            title=f"{self.user.name} has started!",
-            description=f"{self.guild} has {self.guild.member_count:,} members!",
-            colour=0xB01EC3,
-        )
+        startup_message = f'{self.user.name} has started! {self.guild} has {self.guild.member_count:,} members!'
+        embed = discord.Embed(title=f"{self.user.name} has started!",
+                              description=f"{self.guild} has {self.guild.member_count:,} members!", colour=0xb01ec3)
         if self.failed_cogs or self.roles_not_found or self.channels_not_found:
-            embed.colour = 0xE50730
+            embed.colour = 0xe50730
             if self.failed_cogs:
                 embed.add_field(
                     name="Failed to load cogs:",
-                    value="\n".join(
-                        f"**{cog}** - {exc_type}\n"
-                        for cog, exc_type, _ in self.failed_cogs
+                    value='\n'.join(
+                        f"**{cog}** - {exc_type}\n" for cog, exc_type, _ in self.failed_cogs
                     ),
                     inline=False,
                 )
                 for cog, exc_type, exc in self.failed_cogs:
-                    err_embed = discord.Embed(
-                        title=f"Failed to load cog {cog}", colour=0xE50730
-                    )
+                    err_embed = discord.Embed(title=f"Failed to load cog {cog}", colour=0xe50730)
                     trace = "".join(traceback.format_exception(exc))
                     err_embed.description = f"```py\n{trace}\n```"
                     await self.err_channel.send(embed=err_embed)
             if self.roles_not_found:
-                embed.add_field(
-                    name="Roles not Found:",
-                    value=", ".join(self.roles_not_found),
-                    inline=False,
-                )
+                embed.add_field(name="Roles not Found:", value=', '.join(self.roles_not_found), inline=False)
             if self.channels_not_found:
-                embed.add_field(
-                    name="Channels not Found:",
-                    value=", ".join(self.channels_not_found),
-                    inline=False,
-                )
+                embed.add_field(name="Channels not Found:", value=', '.join(self.channels_not_found), inline=False)
 
         logger.info(startup_message)
-        await self.channels["helpers"].send(embed=embed)
+        await self.channels['helpers'].send(embed=embed)
 
         self.tree.app_commands = await self.tree.fetch_commands()
 
@@ -313,70 +266,31 @@ class Kurisu(commands.Bot):
 
     async def load_cogs(self):
         for extension in cogs:
-            if extension == "cogs.server_logs" and SERVER_LOGS_URL == "":
-                logger.info(
-                    "Skipping loading server_logs due to blank server_logs_url."
-                )
+            if extension == 'cogs.server_logs' and SERVER_LOGS_URL == '':
+                logger.info("Skipping loading server_logs due to blank server_logs_url.")
                 continue
             try:
                 await self.load_extension(extension)
             except commands.ExtensionFailed as e:
                 logger.error("%s failed to load.", extension)
-                self.failed_cogs.append(
-                    (extension, type(e.original).__name__, e.original)
-                )
+                self.failed_cogs.append((extension, type(e.original).__name__, e.original))
 
     async def load_channels(self):
-        channels = [
-            "announcements",
-            "welcome-and-rules",
-            "3ds-assistance-1",
-            "3ds-assistance-2",
-            "wiiu-assistance",
-            "switch-assistance-1",
-            "switch-assistance-2",
-            "helpers",
-            "watch-logs",
-            "message-logs",
-            "upload-logs",
-            "hacking-general",
-            "meta",
-            "appeals",
-            "legacy-systems",
-            "dev",
-            "off-topic",
-            "voice-and-music",
-            "bot-cmds",
-            "bot-talk",
-            "mods",
-            "mod-mail",
-            "mod-logs",
-            "server-logs",
-            "bot-err",
-            "elsewhere",
-            "newcomers",
-            "nintendo-discussion",
-            "tech-talk",
-            "hardware",
-            "streaming-gamer",
-            "wii-vwii-assistance",
-        ]
+        channels = ['announcements', 'welcome-and-rules', '3ds-assistance-1', '3ds-assistance-2', 'wiiu-assistance',
+                    'switch-assistance-1', 'switch-assistance-2', 'helpers', 'watch-logs', 'message-logs',
+                    'upload-logs', 'hacking-general', 'meta', 'appeals', 'legacy-systems', 'dev', 'off-topic',
+                    'voice-and-music', 'bot-cmds', 'bot-talk', 'mods', 'mod-mail', 'mod-logs', 'server-logs', 'bot-err',
+                    'elsewhere', 'newcomers', 'nintendo-discussion', 'tech-talk', 'hardware', 'streaming-gamer', 'wii-vwii-assistance']
 
         for n in channels:
             db_channel = await self.configuration.get_channel_by_name(n)
             if db_channel:
                 channel_id = db_channel[0]
                 channel = self.guild.get_channel(channel_id)
-                if channel and isinstance(
-                    channel, (discord.TextChannel, discord.VoiceChannel)
-                ):
+                if channel and isinstance(channel, (discord.TextChannel, discord.VoiceChannel)):
                     self.channels[n] = channel
                     continue
-            channel = discord.utils.find(
-                lambda c: c.name == n
-                and isinstance(c, (discord.TextChannel, discord.VoiceChannel)),
-                self.guild.channels,
-            )
+            channel = discord.utils.find(lambda c: c.name == n and isinstance(c, (discord.TextChannel, discord.VoiceChannel)), self.guild.channels)
             if channel:
                 assert isinstance(channel, (discord.TextChannel, discord.VoiceChannel))
                 self.channels[n] = channel
@@ -386,43 +300,11 @@ class Kurisu(commands.Bot):
                 logger.warning("Failed to find channel %s", n)
 
     async def load_roles(self):
-        roles = [
-            "Helpers",
-            "Staff",
-            "HalfOP",
-            "OP",
-            "SuperOP",
-            "Owner",
-            "On-Duty 3DS",
-            "On-Duty Wii U",
-            "On-Duty Switch",
-            "On-Duty Legacy",
-            "On-Duty Wii",
-            "Probation",
-            "Retired Staff",
-            "Verified",
-            "Trusted",
-            "Muted",
-            "No-Help",
-            "No-elsewhere",
-            "No-Memes",
-            "No-art",
-            "No-animals",
-            "#art-discussion",
-            "No-Embed",
-            "#elsewhere",
-            "Small Help",
-            "meta-mute",
-            "appeal-mute",
-            "crc",
-            "No-Tech",
-            "help-mute",
-            "streamer(temp)",
-            "streamer",
-            "🍰",
-            "No-U",
-            "No-Wii",
-        ]
+        roles = ['Helpers', 'Staff', 'HalfOP', 'OP', 'SuperOP', 'Owner', 'On-Duty 3DS', 'On-Duty Wii U',
+                 'On-Duty Switch', 'On-Duty Legacy', 'On-Duty Wii', 'Probation', 'Retired Staff', 'Verified', 'Trusted', 'Muted',
+                 'No-Help', 'No-elsewhere', 'No-Memes', 'No-art', 'No-animals', '#art-discussion', 'No-Embed', '#elsewhere',
+                 'Small Help', 'meta-mute', 'appeal-mute', 'crc', 'No-Tech', 'help-mute', 'streamer(temp)', 'streamer', '🍰',
+                 'No-U', 'No-Wii']
 
         for n in roles:
             db_role = await self.configuration.get_role(n)
@@ -443,10 +325,10 @@ class Kurisu(commands.Bot):
     async def on_command_error(self, ctx: KurisuContext, exc: commands.CommandError):
         author = ctx.author
         command = ctx.command
-        exc = getattr(exc, "original", exc)
+        exc = getattr(exc, 'original', exc)
         channel = self.err_channel or ctx.channel
 
-        if hasattr(ctx.command, "on_error"):
+        if hasattr(ctx.command, 'on_error'):
             return
 
         if isinstance(exc, commands.CommandNotFound):
@@ -456,12 +338,10 @@ class Kurisu(commands.Bot):
             await ctx.send_help(ctx.command)
 
         elif isinstance(exc, commands.NoPrivateMessage):
-            await ctx.send(f"`{command}` cannot be used in direct messages.")
+            await ctx.send(f'`{command}` cannot be used in direct messages.')
 
         elif isinstance(exc, commands.MissingPermissions):
-            await ctx.send(
-                f"{author.mention} You don't have permission to use `{command}`."
-            )
+            await ctx.send(f"{author.mention} You don't have permission to use `{command}`.")
 
         elif isinstance(exc, InsufficientStaffRank):
             await ctx.send(str(exc))
@@ -469,39 +349,32 @@ class Kurisu(commands.Bot):
         elif isinstance(exc, commands.CheckFailure):
             if ctx.cog and ctx.cog.has_error_handler():
                 return
-            await ctx.send(f"{author.mention} You cannot use `{command}`.")
+            await ctx.send(f'{author.mention} You cannot use `{command}`.')
 
         elif isinstance(exc, commands.MissingRequiredArgument):
-            await ctx.send(
-                f"{author.mention} You are missing required argument `{exc.param.name}`.\n"
-            )
+            await ctx.send(f'{author.mention} You are missing required argument `{exc.param.name}`.\n')
             await ctx.send_help(ctx.command)
             command.reset_cooldown(ctx)
 
         elif isinstance(exc, commands.BadLiteralArgument):
-            await ctx.send(
-                f'Argument {exc.param.name} must be one of the following `{"` `".join(str(literal) for literal in exc.literals)}`.'
-            )
+            await ctx.send(f'Argument {exc.param.name} must be one of the following `{"` `".join(str(literal) for literal in exc.literals)}`.')
             command.reset_cooldown(ctx)
 
         elif isinstance(exc, commands.UserInputError):
-            await ctx.send(f"{author.mention} A bad argument was given: `{exc}`\n")
+            await ctx.send(f'{author.mention} A bad argument was given: `{exc}`\n')
             await ctx.send_help(ctx.command)
             command.reset_cooldown(ctx)
 
         elif isinstance(exc, commands.MaxConcurrencyReached):
-            await ctx.send("This command is already being executed.")
+            await ctx.send('This command is already being executed.')
 
         elif isinstance(exc, commands.errors.CommandOnCooldown):
             try:
                 await ctx.message.delete()
             except (discord.errors.NotFound, discord.errors.Forbidden):
                 pass
-            await ctx.send(
-                f"{author.mention} This command was used {exc.cooldown.per - exc.retry_after:.2f}s ago and is on cooldown. "
-                f"Try again in {exc.retry_after:.2f}s.",
-                delete_after=10,
-            )
+            await ctx.send(f"{author.mention} This command was used {exc.cooldown.per - exc.retry_after:.2f}s ago and is on cooldown. "
+                           f"Try again in {exc.retry_after:.2f}s.", delete_after=10)
 
         elif isinstance(exc, discord.NotFound):
             await ctx.send("ID not found.")
@@ -513,16 +386,12 @@ class Kurisu(commands.Bot):
 
         elif isinstance(exc, commands.CommandInvokeError):
             logger.error("", exc_info=exc)
-            await ctx.send(
-                f"{author.mention} `{command}` raised an exception during usage"
-            )
+            await ctx.send(f'{author.mention} `{command}` raised an exception during usage')
             embed = create_error_embed(ctx, exc)
             await channel.send(embed=embed)
         else:
             logger.error("", exc_info=exc)
-            await ctx.send(
-                f"{author.mention} Unexpected exception occurred while using the command `{command}`"
-            )
+            await ctx.send(f'{author.mention} Unexpected exception occurred while using the command `{command}`')
             embed = create_error_embed(ctx, exc)
             await channel.send(embed=embed)
 
@@ -530,7 +399,7 @@ class Kurisu(commands.Bot):
         logger.error("", exc_info=True)
         if not self.err_channel:
             return
-        embed = discord.Embed(title="Error Event", colour=0xE50730)
+        embed = discord.Embed(title="Error Event", colour=0xe50730)
         embed.add_field(name="Event Method", value=event_method)
         trace = traceback.format_exc()
         embed.description = f"```py\n{trace}\n```"
@@ -551,77 +420,57 @@ class Kuritree(app_commands.CommandTree):
         error: app_commands.AppCommandError,
     ):
 
-        error = getattr(error, "original", error)
+        error = getattr(error, 'original', error)
 
         if isinstance(error, app_commands.CommandNotFound):
             return await interaction.response.send_message(error, ephemeral=True)
 
         author = interaction.user
         ctx = await commands.Context.from_interaction(interaction)
-        command: str = (
-            interaction.command.name
-            if interaction.command is not None
-            else "No command"
-        )
+        command: str = interaction.command.name if interaction.command is not None else "No command"
         channel = self.err_channel or interaction.channel
-        assert isinstance(
-            channel, (discord.TextChannel, discord.VoiceChannel, discord.Thread)
-        )
+        assert isinstance(channel, (discord.TextChannel, discord.VoiceChannel, discord.Thread))
 
         if isinstance(error, app_commands.NoPrivateMessage):
-            await ctx.send(
-                f"`{command}` cannot be used in direct messages.", ephemeral=True
-            )
+            await ctx.send(f'`{command}` cannot be used in direct messages.', ephemeral=True)
 
         elif isinstance(error, app_commands.TransformerError):
             await interaction.response.send_message(error, ephemeral=True)
 
         elif isinstance(error, app_commands.MissingPermissions):
-            await ctx.send(
-                f"{author.mention} You don't have permission to use `{command}`.",
-                ephemeral=True,
-            )
+            await ctx.send(f"{author.mention} You don't have permission to use `{command}`.", ephemeral=True)
 
         elif isinstance(error, AppInsufficientStaffRank):
             await ctx.send(str(error), ephemeral=True)
 
         elif isinstance(error, app_commands.CheckFailure):
-            await ctx.send(
-                f"{author.mention} You cannot use `{command}`.", ephemeral=True
-            )
+            await ctx.send(f'{author.mention} You cannot use `{command}`.', ephemeral=True)
 
         elif isinstance(error, app_commands.CommandOnCooldown):
             await ctx.send(
                 f"{author.mention} This command was used {error.cooldown.per - error.retry_after:.2f}s ago and is on cooldown. "
-                f"Try again in {error.retry_after:.2f}s.",
-                ephemeral=True,
-            )
+                f"Try again in {error.retry_after:.2f}s.", ephemeral=True)
         else:
             if isinstance(error, discord.Forbidden):
                 msg = f"💢 I can't help you if you don't let me!\n`{error.text}`."
             elif isinstance(error, app_commands.CommandInvokeError):
-                msg = f"{author.mention} `{command}` raised an exception during usage"
+                msg = f'{author.mention} `{command}` raised an exception during usage'
             else:
-                msg = f"{author.mention} Unexpected exception occurred while using the command `{command}`"
+                msg = f'{author.mention} Unexpected exception occurred while using the command `{command}`'
 
             await ctx.send(msg, ephemeral=True)
             if channel:
                 embed = create_error_embed(interaction, error)
                 await channel.send(embed=embed)
             else:
-                self.logger.error(
-                    "Error during application command usage.", exc_info=error
-                )
+                self.logger.error("Error during application command usage.", exc_info=error)
 
 
 async def startup():
     setup_logging()
 
     if discord.version_info.major < 2 and discord.version_info.minor < 1:
-        logger.error(
-            "discord.py is not at least 2.1.0x. (current version: %s)",
-            discord.__version__,
-        )
+        logger.error("discord.py is not at least 2.1.0x. (current version: %s)", discord.__version__)
         return 2
 
     if sys.hexversion < 0x30A00F0:  # 3.10
@@ -631,34 +480,27 @@ async def startup():
     if not IS_DOCKER:
         # attempt to get current git information
         try:
-            commit = check_output(["git", "rev-parse", "HEAD"]).decode("ascii")[:-1]
+            commit = check_output(['git', 'rev-parse', 'HEAD']).decode('ascii')[:-1]
         except CalledProcessError as e:
             logger.error("Checking for git commit failed: %s: %s", type(e).__name__, e)
             commit = "<unknown>"
 
         try:
-            branch = check_output(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-            ).decode()[:-1]
+            branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode()[:-1]
         except CalledProcessError as e:
             logger.error("Checking for git branch failed: %s: %s", type(e).__name__, e)
             branch = "<unknown>"
     else:
-        commit = os.environ.get("COMMIT_SHA")
-        branch = os.environ.get("COMMIT_BRANCH")
+        commit = os.environ.get('COMMIT_SHA')
+        branch = os.environ.get('COMMIT_BRANCH')
 
     async with asyncpg.create_pool(DATABASE_URL, min_size=20, max_size=20) as pool:
         logger.info("Starting Kurisu on commit %s on branch %s", commit, branch)
-        bot = Kurisu(
-            command_prefix=[".", "!"],
-            description="Kurisu, the bot for Nintendo Homebrew!",
-            commit=commit,
-            branch=branch,
-            pool=pool,
-        )
+        bot = Kurisu(command_prefix=['.', '!'], description="Kurisu, the bot for Nintendo Homebrew!", commit=commit,
+                     branch=branch, pool=pool)
         bot.help_command = KuriHelp()
 
-        @bot.tree.command(name="help")
+        @bot.tree.command(name='help')
         async def help_app_command(interaction: discord.Interaction):
             """Help for kurisu slash commands."""
 
@@ -674,13 +516,11 @@ async def startup():
             paginator = MainHelpPaginator(mapping, ctx)
             view = HelpView(paginator, ctx)
             view.add_item(CategorySelect(mapping, ctx))
-            await interaction.response.send_message(
-                embed=view.paginator.current(), view=view, ephemeral=True
-            )
+            await interaction.response.send_message(embed=view.paginator.current(), view=view, ephemeral=True)
             view.message = await interaction.original_response()
 
         await bot.start(TOKEN)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     asyncio.run(startup())


### PR DESCRIPTION
<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->

This is an initial implementation of a parser cog for `title.txt` files generated by the `missingtitles` tag (or, more specifically, the Windows `tree` command).

It makes a few checks:
- Is there an `00040000` folder? (Helpee may have run `tree` from the wrong place)
- Are there any empty folders in `title`? (`00040002` pops up quite often in 3ds-assistance)
- For each title in `00040000`...
  - is the `content` folder present?
  - is there a `.app` file?
  - is there a `.tmd` file?
  
It then compiles the output of these checks into an easy-to-read message, as shown below:
![image](https://github.com/user-attachments/assets/8bf928bb-76eb-4af1-bbfb-5baa9b5e185e)
(the "corrupted data" message is triggered when the `tree` parser hits a line it can't handle - in my testing, this generally happens when FAT32 corruption starts putting newline characters into filenames, but if this causes false positives, it can be removed)

I have tested this using real `title.txt` files from assistance channels, with the results matching what helpers have told helpees to do, and I have also verified the results by hand - however, I fully welcome further testing.

I'm not expecting this to be merged immediately. I am open to comments on any aspect of this cog - the parser design and implementation, the wording of the messages sent by Kurisu, and so on and so forth.

I hope this is at least somewhat helpful to others :smile: