### PR TITLE
Change Switch dump guide to git.gay

### DIFF
--- a/cogs/assistance-cmds/dump.switch.md
+++ b/cogs/assistance-cmds/dump.switch.md
@@ -1,8 +1,8 @@
 ---
 title: Switch dump/build Guide
-url: https://dardel.codeberg.page/nxdumpguide
+url: https://dardel.pages.gay/nxdumpguide/
 author.name: Dardel
-author.url: https://dardel.codeberg.page/nxdumpguide
+author.url: https://dardel.pages.gay/nxdumpguide/
 thumbnail-url: https://nintendohomebrew.com/assets/img/HB-browser-icon-full-REMASTERED.png
 help-desc: How to dump games and data for CFW consoles
 ---


### PR DESCRIPTION
git.gay seems to be more consistently up than Codeberg so change the url to that since Codeberg seems to be down every other day.
