### PR TITLE
3DS FTP Tutorial: Remove WinSCP reference

### DIFF
--- a/cogs/assistance-cmds/tutorial/ftp.3ds.md
+++ b/cogs/assistance-cmds/tutorial/ftp.3ds.md
@@ -9,4 +9,4 @@ cooldown-per: 0
 cooldown-rate: 0
 ---
 
-A guide to using ftp with FTPD and WinSCP
+A guide to using ftp with FTPD


### PR DESCRIPTION
The wiki article contains instructions for other operating systems as well