### PR TITLE
Improvements to title.txt parser cog

### DIFF
--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -543,7 +543,7 @@ class TitleTXTParser(commands.Cog):
                     out_message += f"Copy the following folders from the `{folder_name}` folder inside the `title` folder to your computer, then delete them from your SD card:\n"
 
                     for title in folder:
-                        title_clean = title[:8] # TIDs should only be eight characters anyway
+                        title_clean = title[:8]  # TIDs should only be eight characters anyway
                         title_name = self.get_name_by_tid(title_clean)
                         if title_name:
                             if folder_name == _DLC_TIDHIGH:

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -29,7 +29,7 @@ _STREETPASS_TIDLOWS = [
     "00027800",  # KOR
     "00028800",  # TWN
 ]
-_THEME_TIDLOWS = ["0004008c", "00009800"]
+_THEME_TIDLOWS = ["0004008c", "00009800", "000002cc", "00008f00", "000002cd", "000002ce"]
 
 _TREE_INDENT = (
     " " * 3
@@ -210,6 +210,10 @@ class TitleTXTParser(commands.Cog):
 
         for title_id, title in in_tree.items():
             if not isinstance(title, dict):
+                if _HEX_RE.match(title_id) and len(title_id) == 8:
+                    # first observed 2025-04-11 12:32 3ds-assistance-2
+                    # mystery title-like "files?" should be yeeted
+                    bad_titles.append(title_id)
                 continue
 
             flag_ticket_ok = False
@@ -279,8 +283,8 @@ class TitleTXTParser(commands.Cog):
                         flag_app_ok = True
 
             if title_id in bad_titles:
-                # set inside content loop check, break again here
-                break
+                # added to list inside content folder loop, skip to next TID
+                continue
 
             if not (flag_app_ok and flag_tmd_ok):
                 bad_titles.append(title_id)
@@ -539,14 +543,15 @@ class TitleTXTParser(commands.Cog):
                     out_message += f"Copy the following folders from the `{folder_name}` folder inside the `title` folder to your computer, then delete them from your SD card:\n"
 
                     for title in folder:
-                        title_name = self.get_name_by_tid(title)
+                        title_clean = title[:8] # TIDs should only be eight characters anyway
+                        title_name = self.get_name_by_tid(title_clean)
                         if title_name:
                             if folder_name == _DLC_TIDHIGH:
-                                out_message += f"- `{title}` (DLC for {title_name})\n"
+                                out_message += f"- `{title_clean}` (DLC for {title_name})\n"
                             else:
-                                out_message += f"- `{title}` ({title_name})\n"
+                                out_message += f"- `{title_clean}` ({title_name})\n"
                         else:
-                            out_message += f"- `{title}`\n"
+                            out_message += f"- `{title_clean}`\n"
                         title_counter += 1
 
                         if title_counter > _MAX_BROKEN_TITLES:


### PR DESCRIPTION
This is a follow-up PR to #1405 containing improvements to the title.txt parser cog.

- **Issue:** A malformed `title.txt` file may cause Kurisu's reply to exceed 2000 characters. ([#kurisu-development](https://discord.com/channels/196618637950451712/918315061003579482/1359125144680923217))
  - **Resolution:** This was resolved by limiting title IDs to only eight characters. (Line 542)
- **Issue:** A maliciously crafted `title.txt` file may casue a server invite to be embedded into Kurisu's reply, potentially bypassing the server invite allowlist. ([#kurisu-development](https://discord.com/channels/196618637950451712/918315061003579482/1359517752381149335))
  - **Resolution:** This was mitigated by limiting title IDs to only eight characters (Line 542)
- **Issue:** In some cases, HOME Menu theme data may be erroneously flagged as a "bad title". ([#3ds-assistance-2](https://discord.com/channels/196618637950451712/247557068490276864/1360023922405544026))
  - **Resolution:** This was resolved by improving the list of folders which contain theme data. (Line 32)
- **Issue:** In some cases, corrupted DLC data may not be detected by Kurisu.  ([#3ds-assistance-2](https://discord.com/channels/196618637950451712/247557068490276864/1360023922405544026))
  - **Further Details:** Due to a flaw in how DLC data was processed, a DLC title with an empty data folder inside of its `content` folder may have caused processing of DLC data to terminate before all folders had been checked. (Lines 278, 283)
  - **Resolution:** This was resolved by allowing processing to continue to the next DLC data folder when the above condition is met, instead of terminating processing of DLC data. (Line 283)
  
I believe the list of TIDLow values for theme data is now correct (`"0004008c", "00009800", "000002cc", "00008f00", "000002cd", "000002ce"`) - however, if any have been missed, please let me know before merging, and I will update the list accordingly.