### PR TITLE
Changed URL for NSUI usage guide

### DIFF
--- a/cogs/assistance-cmds/vc.3ds.md
+++ b/cogs/assistance-cmds/vc.3ds.md
@@ -8,4 +8,4 @@ help-desc: Link to Virtual Console Injects for 3DS/Wiiu.
 ---
 
 The recommended way to play old classics on your 3DS.
-Usage guide [here](http://3ds.eiphax.tech/nsui.html).
+Usage guide [here](https://wiki.hacks.guide/wiki/3DS:Virtual_Console/Creation).


### PR DESCRIPTION
This PR updates the NSUI usage guide URL from the Eiphax one (https://3ds.eiphax.tech/nsui.html) to the wiki one (https://wiki.hacks.guide/wiki/3DS:Virtual_Console/Creation).

Yea idk I felt bored lmao.