### PR TITLE
made title-fixer_log.txt (and similar things) not be detected as title.txt.

### DIFF
--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -39,7 +39,7 @@ _TREE_FILE_RE = re.compile(r"[\| ]+(\S+)")
 
 _HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
 
-_TITLE_TXT_RE = re.compile(r"[TtIiLlEe]{4,}.+\.[tx]{3,}")
+_TITLE_TXT_RE = re.compile(r"[TtIiLlEe]{4,}[^_]+\.[tx]{3,}")
 
 _SAFE_MENTIONS = AllowedMentions(
     everyone=False, users=False, roles=False, replied_user=True


### PR DESCRIPTION
Made it so `title-fixer_log.txt` and similar don't get captured by the regex (kurisu gets confused ;~;). It is still pretty compliant, just doesn't read underscores after title, so title (1).txt and such still get captured properly.