### PR TITLE
Nospace w/Finalizing Setup

### DIFF
--- a/cogs/assistance-cmds/nospace.3ds.md
+++ b/cogs/assistance-cmds/nospace.3ds.md
@@ -8,7 +8,7 @@ cooldown-per: 15
 
 # Steps to create the backup
 
-1. Copy the Nintendo 3DS folder from the root of your SD card to your computer then delete it from **the SD card.** On Mac, empty the Trash.
-2. Boot GodMode9 by holding START on boot then perform a normal NAND backup. After that, power off the system.
-3. Copy the files in gm9/out on your SD card to a safe spot on your computer. Then, delete the files from **the SD card.**
+1. Copy the Nintendo 3DS folder (and DCIM if it exists) from the root of your SD card to your computer, then delete it from **the SD card.** On Mac, also empty the Trash.
+2. If following Finalizing Setup, hold X on boot, then run the finalize script to perform the NAND backup. If not, hold START on boot and have GM9Megascript back up the NAND using [this guide](https://3ds.hacks.guide/godmode9-usage.html#creating-a-nand-backup). After that, power off the system.
+3. Copy the files in /gm9/out (or /gm9/backups if you have followed Finalizing Setup) on your SD card to a safe spot on your computer. Then, delete the files from **the SD card.**
 4. Copy the Nintendo 3DS folder to your SD card root, then you may keep the copy on your computer as a backup, or delete it **from your computer.**


### PR DESCRIPTION
This PR clarifies how to create space to make a NAND backup when either going through Finalizing Setup or using GM9Megascript.