### PR TITLE
Migrate more tags to commands

### DIFF
--- a/cogs/assistance-cmds/b9scolor.3ds.md
+++ b/cogs/assistance-cmds/b9scolor.3ds.md
@@ -1,0 +1,5 @@
+---
+image-url: https://hacksguidewiki.sfo3.digitaloceanspaces.com/hacksguidewiki/Boot9strap-LED-colors-snapshot.png
+help-desc: Links to a quick image reference of what each boot9strap LED codes mean
+aliases: b9scolors
+---

--- a/cogs/assistance-cmds/bmbt.3ds.md
+++ b/cogs/assistance-cmds/bmbt.3ds.md
@@ -1,0 +1,10 @@
+---
+title: bmbt3DS
+url: https://wiki.hacks.guide/wiki/3DS:Bmbt3DS
+author.name: Gruetzig
+thumbnail-url: https://avatars.githubusercontent.com/u/88926852
+help-desc: Links to a guide to test hardware buttons on the 3DS
+aliases: butttest
+---
+
+Test for broken buttons

--- a/cogs/assistance-cmds/bosscrash.3ds.md
+++ b/cogs/assistance-cmds/bosscrash.3ds.md
@@ -1,0 +1,10 @@
+---
+help-desc: Quick troubleshooting guide for "boss" module crash
+---
+
+If you are having an issue where your 3DS crashes with the "boss" process, this is due to NetPass. You can disable game patching to avoid this by doing:
+
+1. Hold SELECT while turning on the 3DS
+2. At Luma3DS configuration, disable "Enable loading external FIRMs and modules"
+3. Press START to save and exit
+    - If this works, open /luma/sysmodules/ and delete 0004013000003402.ips and  0004013000002602.ips

--- a/cogs/assistance-cmds/f000000b.3ds.md
+++ b/cogs/assistance-cmds/f000000b.3ds.md
@@ -1,0 +1,14 @@
+---
+title: Resolving f000000b corruption
+help-desc: Short guide to fix f000000b errors
+---
+
+1. Insert your SD card into your 3DS if not already
+2. Launch GodMode9 by holding START while powering on your console.
+3. Navigate to `[1:] SYSNAND CTRNAND/data/<ID0>/extdata/00048000/`
+4. Hover over `f000000b`
+5. Press R+A, and select "Copy to `0:/gm9/out`".
+6. Press X on `f000000b` to delete it
+7. When prompted to unlock SysNAND (lvl1) writing, press (A), then input the key combo
+8. When prompted to relock write permissions, press (A)
+9. Press START to reboot your device

--- a/cogs/assistance-cmds/flashdrive.wii.md
+++ b/cogs/assistance-cmds/flashdrive.wii.md
@@ -1,0 +1,13 @@
+---
+title: Why you should not use flash drives
+help-desc: Explanation of why flash drives are bad
+aliases: wiidrive
+---
+
+***Reasons to not use flash drives:***
+- Game backups failing to load
+- UI glitches in homebrew apps
+- Data randomly becoming corrupted
+
+***Recommended Solution:***
+If you experience the issues above, or other inexplicable issues with your flash drive, use a USB HDD or an SD card instead.

--- a/cogs/assistance-cmds/gbasaves.3ds.md
+++ b/cogs/assistance-cmds/gbasaves.3ds.md
@@ -1,0 +1,8 @@
+---
+title: Backup and restore GBA VC save files
+help-desc: Links to guides to dump and restore GBA VC saves
+aliases: 3dsgbavc
+---
+
+Backup GBA VC saves: <https://3ds.hacks.guide/dumping-titles-and-game-cartridges.html#backup-gba-vc-saves>
+Restore GBA VC saves: <https://3ds.hacks.guide/dumping-titles-and-game-cartridges.html#restore-gba-vc-saves>

--- a/cogs/assistance-cmds/hbautoboot.3ds.md
+++ b/cogs/assistance-cmds/hbautoboot.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Disable homebrew autoboot
+help-desc: Steps to disable Luma3DS homebrew autoboot
+---
+
+1. Power off your console
+2. Hold SELECT, and while holding SELECT, power on your console. This will open the Luma configuration menu.
+3. Press <:3ds_dpad_down:295004561670930432> until Hbmenu autoboot is highlighted, then press <:3ds_button_a:295004457098543104> until the option is set to Off (x)
+4. Either press START or select the Save and exit option to reboot and apply this change

--- a/cogs/assistance-cmds/isfshax.wiiu.md
+++ b/cogs/assistance-cmds/isfshax.wiiu.md
@@ -1,0 +1,8 @@
+---
+title: ISFShax Guide
+url: https://gbatemp.net/threads/642258/
+author.name: jan-hofmeier
+help-desc: Links to the ISFShax setup guide
+---
+
+Installing ISFShax on your Wii U

--- a/cogs/assistance-cmds/loadercrash.wii.md
+++ b/cogs/assistance-cmds/loadercrash.wii.md
@@ -1,0 +1,12 @@
+---
+help-desc: Quick steps to check why USB backup loader is crashing
+---
+
+If launching your game backups on USB Loader GX or WiiFlow boots to a black screen or returns to the Wii Menu or Homebrew Channel, there are two things you should check:
+
+Did you install cIOS, following this guide? https://wii.hacks.guide/cios
+Did you layout your drive exactly as shown in this guide? https://wii.hacks.guide/wii-loaders#game-directory-structure
+
+If you have double-checked both of these things and confirmed that they were done correctly, try re-dumping the game using [CleanRip](https://wii.hacks.guide/dump-games)
+
+If you are still running into issues, please run a [SysCheck](https://wii.hacks.guide/syscheck) and post the results here (this will be syscheck.csv in the root).

--- a/cogs/assistance-cmds/magnet.3ds.md
+++ b/cogs/assistance-cmds/magnet.3ds.md
@@ -1,0 +1,5 @@
+---
+image-url: https://i.imgur.com/5e3lKe2.png
+help-desc: Picture of where to place the magnet for ntrboot
+aliases: 3dsmagnet
+---

--- a/cogs/assistance-cmds/mid0.3ds.md
+++ b/cogs/assistance-cmds/mid0.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Fix multiple ID0 issues
+url: https://wiki.hacks.guide/wiki/3DS:Troubleshooting/multiple_ID0
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to a guide to identify correct ID0 from the SD
+---
+
+Remove conflicting ID0 folders from your SD

--- a/cogs/assistance-cmds/mid1.3ds.md
+++ b/cogs/assistance-cmds/mid1.3ds.md
@@ -1,0 +1,9 @@
+---
+title: Fix multiple ID1 issues
+url: https://wiki.hacks.guide/wiki/3DS:Troubleshooting/multiple_ID1
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to a guide to identify correct ID1 from the SD
+---
+
+Remove conflicting ID1 folders from your SD

--- a/cogs/assistance-cmds/mmm.3ds.md
+++ b/cogs/assistance-cmds/mmm.3ds.md
@@ -1,0 +1,10 @@
+---
+title: Manual Movable Migration
+url: https://wiki.hacks.guide/wiki/3DS:Movable_Moveover
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to a guide to manually transfer a movable.sed to perform a data transfer
+aliases: mm
+---
+
+Migrate user data without an official System Transfer

--- a/cogs/assistance-cmds/nnidremove.3ds.md
+++ b/cogs/assistance-cmds/nnidremove.3ds.md
@@ -1,0 +1,10 @@
+---
+title: Remove a NNID with GM9
+help-desc: Quick guide on removing an NNID from the console
+aliases: removennid
+---
+
+**IMPORTANT:** If you are using Pretendo, switch back to Nintendo with Nimbus before following these steps. This will also log you out of your PNID if you have one made!
+
+1. First create a [NAND backup](<https://3ds.hacks.guide/godmode9-usage#creating-a-nand-backup>) (ignore if you recently made one from Finalizing Setup)
+2. Then follow [this guide](<https://3ds.hacks.guide/godmode9-usage#removing-an-nnid-without-formatting-your-console>) to log out of the NNID

--- a/cogs/assistance-cmds/ptm.3ds.md
+++ b/cogs/assistance-cmds/ptm.3ds.md
@@ -1,0 +1,15 @@
+---
+title: To clear PlayTime Management (PTM) data
+help-desc: Quick guide to clear PTM data to avoid crashes
+---
+
+1. open GodMode9 by holding start prior to and during 3ds power on
+2. go to `SYSNAND CTRNAND`
+3. go to `data`
+4. go to `<ID0>` (ID0 is a random looking 32 letter/number folder)
+5. go to `sysdata`
+6. press R+A on `00010022` and hit `Copy to 0:/gm9/out`
+7. once it copies, go into `00010022`
+8. find `00000000` and press X to delete
+    - this will remove all playtime management data for activity log
+9. reboot

--- a/cogs/assistance-cmds/stealthluma.3ds.md
+++ b/cogs/assistance-cmds/stealthluma.3ds.md
@@ -1,0 +1,10 @@
+---
+title: Installing boot9strap (Stealth Luma3DS)
+url: https://wiki.hacks.guide/wiki/3DS:Alternate_Exploits/Installing_boot9strap_(Stealth_Luma3DS)
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to a guide for replacing stealth Luma3DS with official
+aliases: ancientmoon
+---
+
+Replace stealth Luma3DS with official Luma3DS

--- a/cogs/assistance-cmds/udpih.wiiu.md
+++ b/cogs/assistance-cmds/udpih.wiiu.md
@@ -1,8 +1,8 @@
 ---
-title: UDPIH's Recovery Menu
-url: https://github.com/GaryOderNichts/udpih
-author.name: GaryOderNichts
-thumbnail-url: https://avatars.githubusercontent.com/u/12049776?v=4
+title: UDPIH
+url: https://wiki.hacks.guide/wiki/Wii_U:Alternate_Exploits/UDPIH
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
 help-desc: Links to a guide for booting the recovery menu
 ---
 

--- a/cogs/assistance-cmds/validrive.all.md
+++ b/cogs/assistance-cmds/validrive.all.md
@@ -1,0 +1,8 @@
+---
+title: Test for fake SD cards
+help-desc: Links to Validrive to test for fake storage capacity
+---
+
+Use Validrive to test for obvious fake SD card capacity. Only to be used for quick / obvious fake testing.
+
+https://www.grc.com/validrive.htm

--- a/cogs/assistance-cmds/wiilinkdns.wii.md
+++ b/cogs/assistance-cmds/wiilinkdns.wii.md
@@ -1,0 +1,8 @@
+---
+title: WiiLink DNS
+help-desc: Lists the DNS servers for WiiLink servers
+aliases: rc24dns,wiimmfidns
+---
+
+`167.235.229.36` should be your primary DNS.
+`1.1.1.1` should be your secondary DNS.


### PR DESCRIPTION
Commands moved:
- b9scolor (alias b9scolors)
- butttest -> bmbt
- bosscrash
- f000000b 
- wiidrive -> flashdrive
- 3dsgbavc -> gbasaves
- isfshax  
- loadercrash
- magnet (alias 3dsmagnet)
- mid0
- mid1
- mmm (alias mm)
- nnidremove (alias removennid)
- ptm
- stealthluma (alias ancientmoon)
- udpih 
- validrive
- wiilinkdns (alias rc24dns, wiimmfidns)
