### PR TITLE
Removed an obsolete Kurisu-automated message when submitting GodMode9 missing-titles logs.

### DIFF
--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -509,6 +509,13 @@ class TitleTXTParser(commands.Cog):
 
                 if bad_titles is None:
                     # Happens if no "00040000" folder is found
+                    out_message = self.create_header(
+                        "This doesn't look correct. Are you sure you're running the `tree` command in the right folder?",
+                        author=message.author,
+                        filename=f.filename,
+                        count=attach_count,
+                    )
+                    await message.reply(out_message, allowed_mentions=_SAFE_MENTIONS)
                     continue
 
                 if len(bad_titles) == 0:

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -508,14 +508,6 @@ class TitleTXTParser(commands.Cog):
                     continue
 
                 if bad_titles is None:
-                    # Happens if no "00040000" folder is found
-                    out_message = self.create_header(
-                        "This doesn't look correct. Are you sure you're running the `tree` command in the right folder?",
-                        author=message.author,
-                        filename=f.filename,
-                        count=attach_count,
-                    )
-                    await message.reply(out_message, allowed_mentions=_SAFE_MENTIONS)
                     continue
 
                 if len(bad_titles) == 0:

--- a/cogs/titletxtparse.py
+++ b/cogs/titletxtparse.py
@@ -509,13 +509,6 @@ class TitleTXTParser(commands.Cog):
 
                 if bad_titles is None:
                     # Happens if no "00040000" folder is found
-                    out_message = self.create_header(
-                        "This doesn't look correct. Are you sure you're running the `tree` command in the right folder?",
-                        author=message.author,
-                        filename=f.filename,
-                        count=attach_count,
-                    )
-                    await message.reply(out_message, allowed_mentions=_SAFE_MENTIONS)
                     continue
 
                 if len(bad_titles) == 0:


### PR DESCRIPTION
I accidentally pushed the original commit to my forked main branch instead of the `PR_1450` branch. I reverted that commit and made a new one. These changes should work.