### PR TITLE
Update hwtest.hardware.md to mention O2DS, and replacements

### DIFF
--- a/cogs/assistance-cmds/hardware/hwtest.hardware.md
+++ b/cogs/assistance-cmds/hardware/hwtest.hardware.md
@@ -10,4 +10,4 @@ Please note: if the console is unmodded, your only option is to run the test usi
 Once this test has completed, any amount of errors above 0 indicates RAM failure. This is currently unfixable barring a complete motherboard replacement. If you need assistance transferring your files to a new console/motherboard, you can ask in  https://discord.com/channels/196618637950451712/196635695958196224 .
 
 *While it's technically possible to replace the RAM, it's very time consuming, requires a donor board, and would likely end up costing more than a replacement board, or a whole new console.*
-*If your console is an N2DSXL, it may be worth looking into a repair from [Nintendo](<https://www.nintendo.com/>)*
+*If your console is an Old 2DS or New 2DS XL, it may be worth looking into a replacement from [Nintendo](<https://www.nintendo.com/>)*


### PR DESCRIPTION
Nintendo does not repair 3DS family systems anymore. They replace them in repairs.

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
