### PR TITLE
Add hwtest 3DS command

### DIFF
--- a/cogs/assistance-cmds/hwtest.3ds.md
+++ b/cogs/assistance-cmds/hwtest.3ds.md
@@ -1,0 +1,9 @@
+---
+title: 3DS Hardware Test
+url: https://wiki.hacks.guide/wiki/3DS:Hardware_test
+author.name: Wiki Contributors
+thumbnail-url: https://nintendohomebrew.com/assets/img/nhmemes/bigh.png
+help-desc: Links to a guide to test the RAM of a 3DS
+---
+
+Test RAM problems on 3DS


### PR DESCRIPTION
The .hw hwtest is a bit verbose and is also intended to be sent in #hardware, based on phrasing.

This command just links to the wiki article, which is what the tag did before it was deleted.

Sorry if this is seen as redundant, but it would at least be a bit helpful for me, who has begun to just use wikibot when hardware issues appear to occur