### PR TITLE
NX Commands Modernization

### DIFF
--- a/cogs/assistance-cmds/downgrade.switch.md
+++ b/cogs/assistance-cmds/downgrade.switch.md
@@ -9,6 +9,7 @@ Downgrading your firmware on the Switch is not recommended. This will generally 
 # Possible side effects from downgrading:
 * Unable to boot if performed incorrectly.
 * Unable to boot due to a mismatched efuse count.
-* Inability to use your gamecards.
+* Inability to use gamecards due to mismatched lotus firmware
+* Significant ban risk when connecting to Nintendo servers after connecting on a higher version
 * Save data compatibility issues.
 * Games not launching.

--- a/cogs/assistance-cmds/newver.switch.md
+++ b/cogs/assistance-cmds/newver.switch.md
@@ -5,10 +5,11 @@ help-desc: Quick advice for new versions
 
 Currently, the latest Switch system firmware is `{nx_firmware}`.
 
-If your Switch is **unpatched**:
-Atmosphere and Hekate DO NOT currently support {nx_firmware}, BUT unpatched units will always be hackable when the main tools get new releases.
-Wait for further advice and information from us via <#225556031428755456>, where new releases will be posted.
+Atmosphere and Hekate DO currently support {nx_firmware}. Please read the message below for information regarding new updates.
 
-If your Switch is **hardware patched**:
-Any unit that is Mariko or above (aka 'redbox' Switches, Switch Lites, Switch OLED, etc.) is *unlikely to ever be hackable*.
+As of January 26th, 2026, the primary maintainer of Atmosphère, SciresM, has announced that they are retiring from the public hacking scene. Since they have retired, Atmosphère updates will likely take longer to release with future firmware updates. What this means is that, currently, firmware version 21.2.0 is the latest (officially) supported firmware, without any potential uncertainty.
+
+Users should be cautious updating past firmware versions 21.2.0, as Atmosphère may not work on newer firmware versions if Nintendo has implemented any major changes.
+
+Because of this, there is a large likelihood of (potentially dangerous) Atmosphère forks coming into existence because of this. Users are advised not to use these forks, and should wait for proper Atmosphère updates from developers who know what they're doing.
 *Last edited: {last_revision}*

--- a/cogs/assistance-cmds/newver.switch.md
+++ b/cogs/assistance-cmds/newver.switch.md
@@ -11,5 +11,5 @@ As of January 26th, 2026, the primary maintainer of Atmosphère, SciresM, has an
 
 Users should be cautious updating past firmware versions 21.2.0, as Atmosphère may not work on newer firmware versions if Nintendo has implemented any major changes.
 
-Because of this, there is a large likelihood of (potentially dangerous) Atmosphère forks coming into existence because of this. Users are advised not to use these forks, and should wait for proper Atmosphère updates from developers who know what they're doing.
+Because of this, there is a large likelihood of (potentially dangerous) Atmosphère forks coming into existence. Users are advised not to use these forks, and should wait for proper Atmosphère updates from developers who know what they're doing.
 *Last edited: {last_revision}*

--- a/cogs/assistance-cmds/nxcfw.switch.md
+++ b/cogs/assistance-cmds/nxcfw.switch.md
@@ -1,0 +1,7 @@
+---
+title: Why Atmosphere forks and AIO packs are not recommended
+help-desc: Description of why forks and AIO packs are dangerous
+aliases: aio,fork
+---
+
+Atmosphere forks and AIO typically bundle several extras, including custom system modules which can cause issues with booting if they are not compatible with the currently running firmware. As a result, troubleshooting is often required to figure out which one is causing the issue.

--- a/cogs/assistance-cmds/nxcfw.switch.md
+++ b/cogs/assistance-cmds/nxcfw.switch.md
@@ -4,4 +4,4 @@ help-desc: Description of why forks and AIO packs are dangerous
 aliases: aio,fork
 ---
 
-Atmosphere forks and AIO typically bundle several extras, including custom system modules which can cause issues with booting if they are not compatible with the currently running firmware. As a result, troubleshooting is often required to figure out which one is causing the issue.
+Atmosphere forks and AIO packs typically bundle several extras, including custom system modules which can cause issues with booting if they are not compatible with the currently running firmware. As a result, troubleshooting is often required to figure out which one is causing the issue.

--- a/cogs/assistance-cmds/sdinfo.switch.md
+++ b/cogs/assistance-cmds/sdinfo.switch.md
@@ -6,7 +6,7 @@ aliases: sdreco,nxsd,switchsd
 
 The Nintendo Switch can use SD cards up to 2TB in size when formatted to FAT32.
 
-The recommended size is 128GB, however you may want more (256, 512..) if you want to use an emuMMC, run Android or run Linux.
+The minimum recommended size is 128GB, however you may want more (256GB, 512GB..) if you want to use an emuMMC, run Android or run Linux.
 
 The recommended filesystem format is FAT32. While the Switch supports exFAT through an additional update from Nintendo, the filesystem driver used by Nintendo is prone to corruption and as a result is not advisable.
 

--- a/cogs/assistance-cmds/stock.switch.md
+++ b/cogs/assistance-cmds/stock.switch.md
@@ -3,14 +3,9 @@ title: Looking to hack your Switch?
 help-desc: Advisory for various Nintendo systems on stock firmware
 ---
 
-Use [our guide](https://switch.hacks.guide/user_guide/getting_started/) to determine if your Switch is a first-gen unit.
+Use [our guide](https://switch.hacks.guide/user_guide/getting_started/) to determine if your Switch is an unpatched unit.
 **First generation consoles (RCM exploitable)**
 All of these can run [Atmosphere](https://switch.hacks.guide/). Make sure that Atmosphere is compatible with the latest firmware version before you update.
 
 **Second generation consoles ("patched" units, Switch Lite, Mariko, etc.)**
-
-**"Old" Patched Switch (HAC-001)**: Do NOT update past 7.0.1. Units on 7.0.1 and below will eventually get CFW. Units on 8.0.0 and higher are not expected to be hacked and can be updated.
-**"New" Switch (HAC-001-01)**: Do NOT update past 8.0.1. Units on 8.0.1 and below will likely get homebrew. Units on 8.1.0 and higher are not expected to be hacked and can be updated.
-**Switch Lite (HDH-001)**: Do NOT update past 8.0.1. Units on 8.0.1 and below will likely get homebrew. Units on 8.1.0 and higher are not expected to be hacked and can be updated.
-
-Downgrading is **impossible** on patched consoles, and isn't worth your time on unpatched ones.
+Patched consoles can not (and never will) be modded through software on 5.0.0+. In order to run Atmosphere, you must install a modchip.

--- a/cogs/assistance-cmds/stock.switch.md
+++ b/cogs/assistance-cmds/stock.switch.md
@@ -8,4 +8,4 @@ Use [our guide](https://switch.hacks.guide/user_guide/getting_started/) to deter
 All of these can run [Atmosphere](https://switch.hacks.guide/). Make sure that Atmosphere is compatible with the latest firmware version before you update.
 
 **Second generation consoles ("patched" units, Switch Lite, Mariko, etc.)**
-Patched consoles can not (and never will) be modded through software on 5.0.0+. In order to run Atmosphere, you must install a modchip.
+Patched consoles are not (and never will be) moddable through software on 5.0.0+. In order to run Atmosphere, you must install a modchip.

--- a/cogs/assistanceswitch.py
+++ b/cogs/assistanceswitch.py
@@ -21,10 +21,10 @@ class AssistanceSwitch(commands.Cog):
     """
 
     format_map = {
-        'nx_firmware': '16.0.1',
-        'ams_ver': '1.5.1',
-        'hekate_ver': '6.0.2',
-        'last_revision': 'March 28th, 2023',
+        'nx_firmware': '21.2.0',
+        'ams_ver': '1.10.2',
+        'hekate_ver': '6.5.1',
+        'last_revision': 'February 24th, 2026',
     }
 
     # compatibility until the use of these variables is removed

--- a/cogs/assistanceswitch.py
+++ b/cogs/assistanceswitch.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 import logging
 from os.path import dirname, join
-from typing import TYPE_CHECKING
 
 from discord.ext import commands
 
 from utils.mdcmd import add_md_files_as_commands
-from utils.utils import KurisuCooldown, simple_embed
-
-if TYPE_CHECKING:
-    from utils.context import KurisuContext
 
 logger = logging.getLogger(__name__)
 

--- a/cogs/assistanceswitch.py
+++ b/cogs/assistanceswitch.py
@@ -35,48 +35,6 @@ class AssistanceSwitch(commands.Cog):
 
     data_dir = join(dirname(__file__), 'assistance-cmds')
 
-    @commands.dynamic_cooldown(KurisuCooldown(1, 30.0), commands.BucketType.channel)
-    @commands.command()
-    async def nxcfw(self, ctx: KurisuContext, cfw=""):
-        """Information on why we don't support or recommend various other Switch CFWs"""
-
-        if cfw == "sx":  # Alias for sxos
-            cfw = "sxos"
-
-        cfwinfo = {
-            'kosmos': {
-                'info':
-                    ('* Kosmos bundles several extras, including system modules which can cause issues'
-                     ' with booting if they are not compatible with the currently running firmware. '
-                     'As a result, troubleshooting is often required to figure out which one is causing the issue.'),
-                'title': "Kosmos"
-            },
-            'reinx': {
-                'info':
-                    ('* Older versions have caused bans due to the incorrectly implemented user agent string.'
-                     '* The author has expressed no interest in adding emuMMC/emuNAND.'
-                     '* The author has expressed that they feel it doesn\'t matter if consoles get banned.'
-                     '* It often takes weeks to several months for it to get support for the latest firmware.'),
-                'title': "ReiNX"
-            },
-            'sxos': {
-                'info':
-                    (
-                        '* SX OS is illegal to purchase and own. It bundles various keys and copyrighted data that cannot be legally shared.'
-                        '* It has known compatibility issues with homebrew, due to its non-standard and proprietary nature.'
-                        '* It does not support loading custom system modules.'
-                        '* Several versions of the CFW have caused users to be banned without their knowledge.'),
-                'title': "SX OS"
-            }
-        }
-
-        if not (info := cfwinfo.get(cfw)):
-            await ctx.send(f"Please specify a cfw. Valid options are: {', '.join(x for x in cfwinfo)}.")
-
-            ctx.command.reset_cooldown(ctx)
-            return
-        await simple_embed(ctx, info['info'], title=f"Why {info['title']} isn't recommended")
-
 
 add_md_files_as_commands(AssistanceSwitch, console_cmd="switch")
 

--- a/utils/mdcmd.py
+++ b/utils/mdcmd.py
@@ -30,11 +30,13 @@ for k, v in aliases.items():
 # compatibility
 systems = systems_no_aliases + tuple(aliases) + ('legacy',)
 
+# Version table for various Switch software
+# TODO look into merging this with the table in assistanceswitch.py
 format_map = {
-    'nx_firmware': '19.0.1',
-    'ams_ver': '1.8.0',
-    'hekate_ver': '6.2.2',
-    'last_revision': '7th March, 2025',
+    'nx_firmware': '21.2.0',
+    'ams_ver': '1.10.2',
+    'hekate_ver': '6.5.1',
+    'last_revision': 'February 24th, 2026',
 }
 
 


### PR DESCRIPTION
<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->

Major Changes:
- Completely revamped `.nxcfw` to remove outdated information regarding custom firmwares that are no longer being updated. This command is now used to talk about the dangers of all-in-one packs (since the information is relatively similar).
- Updated the newver command to include a disclaimer about the primary developer of Atmosphere retiring potentially causing longer wait times for Atmosphere updates.
- Updated the stock command to mention patched Erista/Mariko users must install a modchip as there will be no software exploit on system versions 5.0.0 and above.

Minor Changes:
- Updated the NX downgrade command to include a warning about a ban risk when trying to connect to Nintendo servers.
- Updated format_map in both `assistanceswitch.py` and `mdcmd.py` to refer to the latest versions of Atmosphere, Hekate, and Horizon OS.
