### PR TITLE
Higher quality result in imgconvert.py

### DIFF
--- a/cogs/imgconvert.py
+++ b/cogs/imgconvert.py
@@ -27,7 +27,6 @@ class ImageConvert(commands.Cog):
     @staticmethod
     def img_convert(in_img: bytes):
         img_obj = Image.open(BytesIO(in_img))
-        img_obj.thumbnail(MAX_SIZE)
         img_out = BytesIO()
         img_obj.save(img_out, 'webp', lossless=False, quality=20)
         img_out.seek(0)


### PR DESCRIPTION
calling .thumbnail() makes the quality descend into illegibility.
If there's a good reason for it, or better solution, ignore this PR (but I would love to know why too).

Also I left MAX_SIZE in for some reason.