### PR TITLE
Add Wii cfwuses; parity between Switch and Wii U cfwuses

### DIFF
--- a/cogs/assistance-cmds/cfwuses.3ds.md
+++ b/cogs/assistance-cmds/cfwuses.3ds.md
@@ -1,5 +1,5 @@
 ---
-help-desc: Uses for CFW on Wii U, Switch, and 3DS
+help-desc: Uses for CFW on 3DS, Switch, Wii and Wii U
 ---
 
 Want to know what CFW can be used for? <https://wiki.hacks.guide/wiki/3DS:Things_to_do>

--- a/cogs/assistance-cmds/cfwuses.switch.md
+++ b/cogs/assistance-cmds/cfwuses.switch.md
@@ -1,16 +1,18 @@
 ---
-title: What can I do with a hacked switch?
-help-desc: Uses for CFW on Wii U, Switch, and 3DS
+title: What can I do with a hacked Switch?
+help-desc: Uses for CFW on 3DS, Switch, Wii and Wii U
 ---
 
-There is no complete list about what is possible and what not, but to give you an idea of what you can do, here is an overview:
+# Among other things, it allows you to do the following:
 
--Have custom themes,
--Run emulators (up to N64 works, with a bit of modification GCN/Wii work fine as well, but it varies from game to game),
--Run custom homebrew apps,
--Backup, edit and restore game saves,
--Dump game cartridges (to look at the contents, for example)
--Mod games,
--Run Android or Linux on your Switch,
--Stream your console's screen over USB/Network (even on Lite consoles),
--Still have access to normal stock features (e.g. eShop, online services etc.)
+- Have custom themes,
+- Run emulators (up to N64 works, with a bit of modification GCN/Wii work fine as well, but it varies from game to game),
+- Run custom homebrew apps,
+- Backup, edit and restore game saves,
+- Dump game cartridges (to look at the contents, for example)
+- Mod games,
+- Run Android or Linux on your Switch,
+- Stream your console's screen over USB/Network (even on Lite consoles),
+- Still have access to normal stock features (e.g. eShop, online services etc.)
+
+**See [here](https://wiki.hacks.guide/wiki/Switch:Things_to_do) for a better list.**

--- a/cogs/assistance-cmds/cfwuses.wii.md
+++ b/cogs/assistance-cmds/cfwuses.wii.md
@@ -1,0 +1,5 @@
+---
+help-desc: Uses for CFW on 3DS, Switch, Wii and Wii U
+---
+
+Want to know what CFW can be used for? <https://wiki.hacks.guide/wiki/Wii:Things_to_do>

--- a/cogs/assistance-cmds/cfwuses.wiiu.md
+++ b/cogs/assistance-cmds/cfwuses.wiiu.md
@@ -1,6 +1,6 @@
 ---
-title: What can Wii U CFW be used for?
-help-desc: Uses for CFW on Wii U, Switch, and 3DS
+title: What can I do with a hacked Wii U?
+help-desc: Uses for CFW on 3DS, Switch, Wii and Wii U
 ---
 
 # Among other things, it allows you to do the following:
@@ -14,4 +14,3 @@ help-desc: Uses for CFW on Wii U, Switch, and 3DS
 - And many more.
 
 **See [here](https://wiki.hacks.guide/wiki/Wii_U:Things_to_do) for a better list.**
-


### PR DESCRIPTION
Copy cfwuses.3ds.md, replace the link with the Wii wiki page link, rename cfwuses.wii.md
Fix bullet points in cfwuses.switch.md and make it have the same structure as cfwuses.wiiu.md
Finally, change all descriptions to add Wii and order it alphabetically (feel free to change, I don't know the context behind original order of Wii U, Switch, 3DS)