### PR TITLE
Update SD card recommendations for Wii

### DIFF
--- a/cogs/assistance-cmds/sdinfo.wii.md
+++ b/cogs/assistance-cmds/sdinfo.wii.md
@@ -9,6 +9,5 @@ The minimum SD card requirements for Wii homebrew is 2GB, and **must** be FAT32 
 The recommended size is 32GB, you can typically use any size under that. The maximum size limit is 2TB. 
 
 Buy SD cards from reputable brands (Samsung, Kingston, Amazon Basics, Lexar, etc.). Preferably, purchase cards from a brick and mortar store near you, but Amazon is okay if you must purchase online. __**NEVER**__ buy cards from AliExpress, Temu, eBay or other similar sites.
-While SanDisk did make official SD cards for the Wii back in the day, their newer SD cards tend to have issues with BootMii in boot2, and fakes are too common to be worth the risk over Samsung or Kingston.
 
 Speed is irrelevant for the Wii - it is limited to 25MB/s speeds. The only reason to buy a faster SD card is for faster data transfer to your computer.


### PR DESCRIPTION
Removed outdated information about SanDisk SD cards and their compatibility with BootMii.

Though I've been told by aep that this SanDisk disclaimer is definitely true, I think we've seen like... two such cases, max. And I very much doubt it was because of something special with how a SanDisk SD works. Plenty of new users have bought new SanDisk SDs and have had no issues.

<!--
* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
-->
