### PR TITLE
assistancehardware.py: Add nx/ns alias

### DIFF
--- a/cogs/assistancehardware.py
+++ b/cogs/assistancehardware.py
@@ -166,6 +166,8 @@ alias = {
     "ktr": "new3ds",
     "red": "new3dsxl",
     "jan": "new2dsxl",
+    "nx": "switch",
+    "ns": "switch",
     "hac": "switch",
     "hdh": "switchlite",
     "heg": "switcholed",


### PR DESCRIPTION
Add nx and ns aliases for hardware commands, mainly for the .bit command.