### PR TITLE
warns.py: Add mention

### DIFF
--- a/utils/warns.py
+++ b/utils/warns.py
@@ -69,7 +69,7 @@ class WarnsManager(BaseManager, db_manager=WarnsDatabaseManager):
                 to_send = f'You were warned on {guild.name}.'
                 if reason is not None:
                     to_send += ' The given reason is: ' + reason
-                to_send += f'\n\nPlease read the rules in {self.bot.channels["welcome-and-rules"]}. This is your {ordinal(count)} warning.'
+                to_send += f'\n\nPlease read the rules in {self.bot.channels["welcome-and-rules"].mention}. This is your {ordinal(count)} warning.'
                 try:
                     to_send += '\n\n' + warn_extras[count - 1]
                 except (TypeError, IndexError):


### PR DESCRIPTION
Change warn text by adding `.mention` so as to mention the channel by link instead of just sending the channel name
