### PR TITLE
fix nx.eiphax.tech links being borked

### DIFF
--- a/cogs/assistance-cmds/baninfo.switch.md
+++ b/cogs/assistance-cmds/baninfo.switch.md
@@ -1,6 +1,6 @@
 ---
 title: NX Bans
-url: https://nx.eiphax.tech/ban.html
+url: https://nx.eiphax.tech/ban
 thumbnail-url: https://nintendohomebrew.com/assets/img/gunther.png
 help-desc: Links to ban information pages
 ---

--- a/cogs/assistance-cmds/catalyst.switch.md
+++ b/cogs/assistance-cmds/catalyst.switch.md
@@ -4,4 +4,4 @@ help-desc: Link to problem solvers
 ---
 
 Please visit the following page and read the information provided.
-https://nx.eiphax.tech/catalyst.html
+https://nx.eiphax.tech/catalyst

--- a/cogs/assistance-cmds/what.switch.md
+++ b/cogs/assistance-cmds/what.switch.md
@@ -1,6 +1,6 @@
 ---
 title: what?
-url: https://nx.eiphax.tech/nutshell.html
+url: https://nx.eiphax.tech/nutshell
 thumbnail-url: https://nintendohomebrew.com/assets/img/eip2.png
 help-desc: Links to 'what' style pages
 ---


### PR DESCRIPTION
the ".html" in the link causes the pages to not load correctly anymore, removing it fixes it on all pages that have it